### PR TITLE
feat(ci): 新增测试部署与 GitHub Pages 发布工作流

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,60 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+      - '.gitignore'
+      - '.dockerignore'
+      - 'Dockerfile'
+      - 'docker-compose*'
+      - 'nginx*'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      NODE_OPTIONS: '--max-old-space-size=4096'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+          cache: bun
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Cache Docusaurus build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .docusaurus
+            node_modules/.cache
+          key: ${{ runner.os }}-docusaurus-build-${{ hashFiles('bun.lock', 'docusaurus.config.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-docusaurus-build-
+
+      - name: Build website
+        run: bun run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,0 +1,53 @@
+name: Test deployment
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+      - '.gitignore'
+      - '.dockerignore'
+      - 'Dockerfile'
+      - 'docker-compose*'
+      - 'nginx*'
+      - '.github/workflows/docker-publish.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test-deploy:
+    name: Test deployment
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: '--max-old-space-size=4096'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+          cache: bun
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Cache Docusaurus build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .docusaurus
+            node_modules/.cache
+          key: ${{ runner.os }}-docusaurus-build-${{ hashFiles('bun.lock', 'docusaurus.config.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-docusaurus-build-
+
+      - name: Lint and Format check
+        run: |
+          bunx eslint .
+          bunx prettier --check .
+
+      - name: Test build website
+        run: bun run build -- --no-minify


### PR DESCRIPTION
## 变更背景
为提升静态站点发布流程的自动化与稳定性，本次补充 CI/CD 工作流能力，覆盖拉取请求验证与 GitHub Pages 发布场景。

## 主要改动
- 新增测试部署工作流：在拉取请求阶段执行自动化校验，提前发现构建与配置问题
- 新增 GitHub Pages 部署工作流：规范发布流程，支持站点自动发布
- 优化工作流编排与触发逻辑，提升交付一致性

## 影响范围
- 仅涉及 GitHub Actions 工作流配置
- 不涉及业务代码与页面内容变更

## 验证建议
- 在 PR 上触发测试部署流程，确认关键步骤通过
- 在主分支触发发布流程，确认 Pages 站点可正常更新

## 风险与回滚
- 风险较低，主要为工作流配置风险
- 如发布异常，可回滚相关 workflow 提交并重新触发流程