### PR TITLE
docs: add complete Git tools documentation

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-bunx --bundle commitlint --edit "$1"
+bun node_modules/.bin/commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,4 +5,4 @@ if [ "$BRANCH" = "main" ]; then
   exit 1
 fi
 
-bunx lint-staged
+bun node_modules/.bin/lint-staged

--- a/docs/tools/git/advanced.mdx
+++ b/docs/tools/git/advanced.mdx
@@ -1,0 +1,275 @@
+---
+title: 🛡️ Git 进阶操作
+sidebar_position: 3
+description: 掌握 Interactive Rebase、Git Bisect、Reflog、Cherry-pick 等进阶命令，应对复杂开发场景。
+---
+
+当你已经掌握日常工作流后，进阶操作能让你在复杂场景下依然游刃有余。本章介绍四个核心进阶命令。
+
+<a id="interactive-rebase"></a>
+## 🔄 Interactive Rebase
+
+`git rebase -i` 是**重写提交历史**最强大的工具。它允许你编辑、重排、合并、拆分或删除已有的提交。
+
+### 基本用法
+
+```bash
+# 对最近 3 个提交进行交互式 rebase
+git rebase -i HEAD~3
+
+# 对某个提交之后的所有提交进行 rebase
+git rebase -i <commit-hash>
+```
+
+运行后会打开编辑器，列出每个提交及操作指令：
+
+```
+pick abc1234 feat: add user login
+pick def5678 fix: correct login validation
+pick ghi9012 docs: update README
+
+# Commands:
+# p, pick   = 保留该提交（默认）
+# r, reword = 保留提交但修改 message
+# e, edit   = 暂停，修改内容后可继续
+# s, squash  = 合并到前一个提交（保留 message）
+# f, fixup   = 合并到前一个提交（丢弃 message）
+# d, drop    = 删除该提交
+# x, exec    = 执行 shell 命令
+```
+
+### 常见场景
+
+**场景 1：合并多个「修复」提交**
+
+开发中常出现 `fix: typo`、`fix: lint` 等琐碎提交，合并到主分支前应整理：
+
+```
+# rebase 前
+abc1234 feat: add user login
+def5678 fix: typo in login
+efg7890 fix: eslint warnings
+
+# rebase 编辑（将后两个改为 fixup）
+pick abc1234 feat: add user login
+fixup def5678 fix: typo in login
+fixup efg7890 fix: eslint warnings
+
+# rebase 后（变成一个干净的提交）
+abc1234 feat: add user login
+```
+
+**场景 2：修改旧提交的 Message**
+
+```bash
+# 对包含目标提交的历史进行 rebase
+git rebase -i HEAD~5
+# 将目标提交的操作改为 `reword`，保存退出后 Git 会逐个打开编辑器让你修改 message
+```
+
+**场景 3：拆分一个提交**
+
+```bash
+# 1. 对目标提交执行 rebase，操作改为 `edit`
+git rebase -i HEAD~3
+# edit abc1234 feat: add feature X（这个提交里混了多件事）
+
+# 2. Git 会暂停在目标提交，此时撤销该提交的变更但保留在工作区
+git reset HEAD~1
+
+# 3. 逐个文件/代码块重新提交（原子化）
+git add src/part-a.ts && git commit -m "feat: add part A"
+git add src/part-b.ts && git commit -m "feat: add part B"
+
+# 4. 继续 rebase
+git rebase --continue
+```
+
+:::warning[⚠️ Rebase 的黄金法则]
+
+**永远不要 rebase 已经推送到远程的提交**，除非你确定团队其他成员没有基于这些提交工作。改写公共历史会导致协作灾难。
+
+如果必须 rebase 已推送的提交，使用 `git push --force-with-lease` 而非 `git push --force`。
+
+:::
+
+<a id="git-bisect"></a>
+## 🔍 Git Bisect——二分查找 Bug
+
+当发现了一个 Bug，但不知道是哪个提交引入的，`git bisect` 可以通过二分查找，快速定位到「第一个引入 Bug 的提交」。
+
+### 基本流程
+
+```bash
+# 1. 开始 bisect 会话
+git bisect start
+
+# 2. 标记当前版本有 Bug（bad）
+git bisect bad
+
+# 3. 标记某个已知没 Bug 的版本（good）
+git bisect good v2.0.0
+
+# Git 会自动切换到中间的提交，你测试后标记
+# （重复以下步骤直到 Git 告诉你答案）
+
+# 4. 测试当前版本，标记 good 或 bad
+git bisect bad    # 这个版本有 Bug
+git bisect good   # 这个版本没问题
+
+# 5. Git 找到答案后，会输出类似：
+# Bisecting: 0 revisions left to test after this (roughly 0 steps)
+# 8a3f2c1 is the first bad commit
+# Author: ...
+# Date: ...
+# fix: update cache logic    ← 这就是引入 Bug 的提交！
+
+# 6. 结束 bisect 会话，回到原分支
+git bisect reset
+```
+
+### 自动化 Bisect（高效方式）
+
+如果有可自动运行的测试脚本，`git bisect run` 可以全自动完成查找：
+
+```bash
+# 运行自动化二分查找
+# 脚本返回 0 = good，返回 1-127 = bad
+git bisect run npm test
+
+# 自定义脚本
+git bisect run bash -c "node -e 'require(\"./dist/index.js\").test()'"
+```
+
+### Bisect 最佳实践
+
+| 要点 | 说明 |
+| :--- | :--- |
+| **提交要原子化** | 每个提交只做一件事，bisect 才能精准定位到具体代码行 |
+| **Good 版本要准确** | 选一个确实没 Bug 的历史版本，否则 bisect 会给出错误答案 |
+| **用 `run` 自动化** | 手动测试 10+ 个提交很累，写测试脚本让 Git 全自动跑 |
+
+<a id="git-reflog"></a>
+## 📜 Git Reflog——引用日志
+
+`git reflog` 记录了 **HEAD 和分支引用在过去的所有移动**。它是你的「后悔药」——即使提交被删除或分支被重置，只要还在 reflog 里（默认保留 90 天），就能找回来。
+
+### 查看 Reflog
+
+```bash
+# 查看 HEAD 的引用日志
+git reflog
+
+# 输出示例：
+# abc1234 (HEAD -> main, origin/main) HEAD@{0}: commit: fix: auth timeout
+# def5678 HEAD@{1}: commit: feat: add user dashboard
+# ghi9012 HEAD@{2}: reset: moving to HEAD~2
+# jkl3456 HEAD@{3}: commit: wip: broken feature
+# mno7890 HEAD@{4}: pull: Fast-forward from main to origin/main
+```
+
+### 用 Reflog 恢复丢失的提交
+
+```bash
+# 场景：不小心 git reset --hard 丢掉了几个提交
+# 解决：从 reflog 找到丢失的提交，reset 回去
+
+git reflog
+# 发现 abc1234 是丢失前的状态
+
+git reset --hard abc1234
+# 成功恢复！所有「丢失」的提交都回来了
+```
+
+### Reflog 与 `git log` 的区别
+
+| | `git log` | `git reflog` |
+| :--- | :--- | :--- |
+| **显示内容** | 提交历史（DAG） | HEAD/分支的移动记录 |
+| **包含已删除提交** | ❌ 不包含 | ✅ 包含（在过期前） |
+| **主要用途** | 查看项目演变 | 恢复误操作丢失的提交 |
+| **数据保留期** | 永久 | 默认 90 天 |
+
+:::tip[💡 Reflog 不是永久的]
+
+Reflog 数据会在过期后自动清理（默认 90 天）。如果你发现重要提交「消失」了，越快用 reflog 恢复越好。
+
+:::
+
+<a id="cherry-pick"></a>
+## 🍒 Cherry-pick——遴选提交
+
+`git cherry-pick` 将**某个（些）提交**应用到当前分支，而不需要合并整个分支。适用于「只想拿某个提交，不要其他变更」的场景。
+
+### 基本用法
+
+```bash
+# 将提交 abc1234 的变更应用到当前分支
+git cherry-pick abc1234
+
+# 遴选多个提交（按顺序排列）
+git cherry-pick abc1234 def5678
+
+# 遴选但不自动提交（让你先检查/修改）
+git cherry-pick --no-commit abc1234
+```
+
+### 常见场景
+
+**场景 1：将 Hotfix 同时应用到多个分支**
+
+```
+# 假设 main 分支发现了一个紧急 Bug，你在 main 上提交了修复：
+# fix: patch security vulnerability (commit: sec1234)
+
+# 但 staging 分支也需要这个修复，又不想合并整个 main...
+git checkout staging
+git cherry-pick sec1234
+# staging 分支现在也有了 sec1234 的修复，但没有 main 上的其他变更
+```
+
+**场景 2：从错误分支上「抢救」提交**
+
+```
+# 你不小心在 main 上直接提交了功能代码（应该提交到 feature 分支）
+# 解决：在 feature 分支 cherry-pick 这个提交，然后在 main 上 revert
+
+git checkout feature-x
+git cherry-pick abc1234    # 把提交拿到 feature 分支
+
+git checkout main
+git revert abc1234          # 在 main 上撤回这个提交
+```
+
+### Cherry-pick 冲突处理
+
+Cherry-pick 可能产生冲突，处理方式与 merge 冲突类似：
+
+```bash
+# 发生冲突时
+git status    # 查看冲突文件
+
+# 手动解决冲突后
+git add <conflicted-files>
+git cherry-pick --continue
+
+# 或者放弃此次 cherry-pick
+git cherry-pick --abort
+```
+
+---
+
+## 📝 下一步
+
+掌握进阶操作后，建议继续学习：
+
+- **[✍️ 提交规范](./commit-conventions)** —— Conventional Commits 规范与工具配置
+- **[📝 Git 速查表](./cheat-sheet)** —— 所有常用命令一览
+
+:::tip[💡 延伸阅读]
+
+- [Pro Git - Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
+- [Git Bisect Documentation](https://git-scm.com/docs/git-bisect)
+- [Reflog - Your Safety Net](https://www.atlassian.com/git/tutorials/refs-and-the-reflog)
+
+:::

--- a/docs/tools/git/cheat-sheet.mdx
+++ b/docs/tools/git/cheat-sheet.mdx
@@ -1,6 +1,6 @@
 ---
 title: 📝 Git 速查表
-sidebar_position: 5
+sidebar_position: 99
 description: Git 常用命令速查表，按场景分类，快速查找所需命令。
 ---
 

--- a/docs/tools/git/cheat-sheet.mdx
+++ b/docs/tools/git/cheat-sheet.mdx
@@ -1,0 +1,341 @@
+---
+title: 📝 Git 速查表
+sidebar_position: 5
+description: Git 常用命令速查表，按场景分类，快速查找所需命令。
+---
+
+本页汇总 Git 日常开发中最常用的命令，按使用场景分类，方便快速查阅。
+
+:::tip[💡 使用方式]
+
+遇到不熟悉的命令，先 `git <command> --help` 查看官方文档，或 `git <command> -h` 查看简短帮助。
+
+:::
+
+<a id="setup-config"></a>
+## ⚙️ 安装与配置
+
+```bash
+# 查看版本
+git --version
+
+# 配置用户信息（全局）
+git config --global user.name "Your Name"
+git config --global user.email "your@email.com"
+
+# 配置默认编辑器
+git config --global core.editor "code --wait"   # VS Code
+git config --global core.editor "vim"             # Vim
+git config --global core.editor "nano"            # Nano
+
+# 查看所有配置
+git config --global --list
+
+# 配置别名（提效）
+git config --global alias.co checkout
+git config --global alias.br branch
+git config --global alias.ci commit
+git config --global alias.st status
+git config --global alias.lg "log --oneline --graph --all"
+git config --global alias.unstage "reset HEAD --"
+```
+
+<a id="create-init"></a>
+## 📁 创建与初始化
+
+```bash
+# 初始化新仓库
+git init
+
+# 克隆远程仓库
+git clone https://github.com/user/repo.git
+git clone git@github.com:user/repo.git        # SSH 方式
+
+# 克隆指定分支
+git clone -b main https://github.com/user/repo.git
+
+# 克隆到指定目录
+git clone https://github.com/user/repo.git my-folder
+```
+
+<a id="basic-workflow"></a>
+## 🔄 日常基本工作流
+
+```bash
+# 查看状态（最常用！）
+git status
+
+# 查看变更详情
+git diff                # 工作区 vs 暂存区
+git diff --staged       # 暂存区 vs 最新提交
+git diff HEAD           # 工作区 vs 最新提交
+
+# 暂存变更
+git add <file>         # 暂存指定文件
+git add .               # 暂存所有（谨慎！）
+git add -p              # 交互式暂存（推荐）
+
+# 提交
+git commit -m "message"
+git commit              # 打开编辑器写多行 message
+git commit --amend      # 修正最后一次提交
+
+# 推送
+git push
+git push -u origin main # 首次推送并绑定
+
+# 拉取
+git pull                # fetch + merge
+git pull --rebase      # fetch + rebase（推荐）
+```
+
+<a id="branch-operations"></a>
+## 🌿 分支操作
+
+```bash
+# 查看分支
+git branch              # 本地分支
+git branch -a           # 所有分支（含远程）
+git branch -v           # 显示最新提交
+
+# 创建与切换
+git branch <name>       # 创建分支
+git checkout -b <name>  # 创建并切换（旧版）
+git switch -c <name>    # 创建并切换（新版推荐）
+
+# 切换分支
+git checkout <name>
+git switch <name>
+
+# 合并分支
+git merge <branch>      # 合并到当前分支
+git merge --no-ff <branch>  # 强制产生 merge commit
+
+# 变基（改写历史，慎用！）
+git rebase <base-branch>
+git rebase -i HEAD~3   # 交互式 rebase
+
+# 删除分支
+git branch -d <name>    # 已合并，可删除
+git branch -D <name>    # 强制删除（未合并）
+```
+
+<a id="history-view"></a>
+## 📜 历史查看
+
+```bash
+# 基本 log
+git log
+git log --oneline       # 简洁格式
+git log --graph --all   # 图形化分支 history
+
+# 查看某文件的历史
+git log -- <file>
+git log -p -- <file>   # 附带 diff
+
+# 查看某行代码的作者（责追究器）
+git blame <file>
+git blame -L 10,20 <file>  # 只看第 10-20 行
+
+# 查看某次提交的详情
+git show <commit-hash>
+git show HEAD            # 查看最新提交
+```
+
+<a id="undo-changes"></a>
+## ⏪ 撤销与回滚
+
+```bash
+# 撤销工作区的修改（危险！文件内容会丢失）
+git restore <file>              # Git 2.23+
+git checkout -- <file>          # 旧版命令
+
+# 撤销暂存区的文件（保留工作区修改）
+git restore --staged <file>    # Git 2.23+
+git reset HEAD <file>           # 旧版命令
+
+# 撤销提交（保留修改在工作区）
+git reset --soft HEAD~1        # 回退 1 个提交，修改留在暂存区
+git reset HEAD~1                # 回退 1 个提交，修改留在工作区
+
+# 硬回滚（危险！所有修改丢失）
+git reset --hard HEAD~1        # 回退 1 个提交，丢弃所有修改
+git reset --hard <commit-hash>  # 回退到指定提交
+
+# 用新提交撤销旧提交（安全，推荐用于已推送的提交）
+git revert <commit-hash>
+```
+
+<a id="remote-operations"></a>
+## 🌐 远程操作
+
+```bash
+# 查看远程仓库
+git remote -v
+
+# 添加远程仓库
+git remote add origin https://github.com/user/repo.git
+
+# 修改远程仓库地址
+git remote set-url origin https://github.com/user/new-repo.git
+
+# 拉取远程更新（不合并）
+git fetch
+git fetch --all
+
+# 推送
+git push
+git push origin <branch>
+git push --force-with-lease   # 安全强制推送
+
+# 删除远程分支
+git push origin --delete <branch>
+```
+
+<a id="stash-operations"></a>
+## 📦 Stash（暂存工作现场）
+
+```bash
+# 暂存当前工作（未提交的修改）
+git stash
+git stash push -m "WIP: feature X"   # 带描述
+
+# 查看 stash 列表
+git stash list
+
+# 恢复 stash（不删除）
+git stash apply stash@{0}
+
+# 恢复 stash（删除）
+git stash pop stash@{0}
+
+# 删除 stash
+git stash drop stash@{0}
+git stash clear            # 清空所有 stash
+```
+
+<a id="tag-operations"></a>
+## 🏷️ 标签操作
+
+```bash
+# 查看标签
+git tag
+
+# 创建轻量标签
+git tag v1.0.0
+
+# 创建附注标签（推荐）
+git tag -a v1.0.0 -m "Release v1.0.0"
+
+# 推送标签到远程
+git push origin v1.0.0
+git push origin --tags     # 推送所有标签
+
+# 删除标签
+git tag -d v1.0.0                # 本地删除
+git push origin :refs/tags/v1.0.0  # 远程删除
+```
+
+<a id="advanced-commands"></a>
+## 🛡️ 进阶命令速查
+
+```bash
+# ===== Git Bisect（二分查找 Bug）=====
+git bisect start
+git bisect bad                    # 当前版本有 Bug
+git bisect good v2.0.0            # v2.0.0 没 Bug
+# ...测试每个版本，标记 good/bad...
+git bisect reset                    # 结束后清理
+
+# 自动化 bisect
+git bisect start
+git bisect bad
+git bisect good v2.0.0
+git bisect run npm test            # 自动运行测试
+
+# ===== Git Reflog（找回丢失的提交）=====
+git reflog                        # 查看 HEAD 移动历史
+git reset --hard HEAD@{2}         # 回到 reflog 中的某个状态
+
+# ===== Cherry-pick（遴选提交）=====
+git cherry-pick <commit-hash>     # 应用指定提交
+git cherry-pick <hash1> <hash2>  # 应用多个提交
+git cherry-pick --no-commit <hash> # 应用但不提交
+
+# ===== Clean（清理未跟踪文件）=====
+git clean -n                       # 预览将要删除的文件（dry run）
+git clean -f                       # 强制删除未跟踪文件
+git clean -fd                      # 删除未跟踪文件和目录
+```
+
+<a id="gitignore"></a>
+## 🚫 .gitignore 模板
+
+```
+# ===== 依赖 =====
+node_modules/
+venv/
+__pycache__/
+
+# ===== 构建产物 =====
+dist/
+build/
+out/
+.next/
+.nuxt/
+
+# ===== 环境配置 =====
+.env
+.env.local
+.<environment>.local
+
+# ===== 日志 =====
+*.log
+npm-debug.log*
+yarn-debug.log*
+
+# ===== 系统文件 =====
+.DS_Store
+Thumbs.db
+
+# ===== IDE =====
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# ===== 测试覆盖率 =====
+coverage/
+*.lcov
+
+# ===== 临时文件 =====
+*.tmp
+*.bak
+*.cache
+```
+
+---
+
+## 📝 速查表总结
+
+| 场景 | 命令 |
+| :--- | :--- |
+| **查看状态** | `git status` |
+| **暂存文件** | `git add <file>` / `git add -p` |
+| **提交** | `git commit -m "message"` |
+| **推送** | `git push` |
+| **拉取** | `git pull --rebase` |
+| **创建分支** | `git switch -c <name>` |
+| **合并分支** | `git merge <branch>` |
+| **查看历史** | `git log --oneline --graph` |
+| **撤销工作区** | `git restore <file>` |
+| **硬回滚** | `git reset --hard HEAD~1` |
+| **安全回滚** | `git revert <hash>` |
+| **找回丢失提交** | `git reflog` → `git reset --hard` |
+| **二分查 Bug** | `git bisect start` |
+
+:::tip[💡 记住这句话]
+
+> **「先 `git status`，再行动。」** —— 任何时候不确定，先跑 `git status` 看看当前状态，比瞎猜强一百倍。
+
+:::

--- a/docs/tools/git/ci-cd.mdx
+++ b/docs/tools/git/ci-cd.mdx
@@ -1,0 +1,255 @@
+---
+title: 🏭 现代工程化与 CI/CD 集成
+sidebar_position: 8
+description: 掌握 GitHub Actions、GitLab CI 中的 Git 操作，以及语义化版本与 Changelog 自动化，构建完整的工程化流水线。
+---
+
+现代软件开发早已不是"写完代码就结束"。从提交到发布，需要经过自动化测试、代码检查、构建、部署等一系列步骤。Git 是这一切的触发器和记录者。
+
+<a id="github-actions"></a>
+## 🤖 GitHub Actions 中的 Git 操作
+
+### 基础：在 Actions 中操作 Git
+
+```yaml
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # 全量克隆，保留完整历史（默认值 1 会导致 merge-base 计算错误）
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+```
+
+### 关键配置：`actions/checkout` 参数
+
+| 参数 | 默认值 | 说明 |
+| :--- | :--- | :--- |
+| `fetch-depth` | `1` | 克隆深度，`0` = 全量（需要完整历史时用） |
+| `ref` | 触发事件的 ref | 指定检出的分支/tag/commit |
+| `token` | `GITHUB_TOKEN` | 认证 token，推送时需要 `permissions` 配置 |
+
+### 场景 1：自动发布版本（Semantic Release）
+
+```yaml
+name: Release
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # 需要写权限来创建 tag 和 release
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Semantic Release
+        uses: cycjimy/semantic-release-action@v4
+        with:
+          branch: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+### 场景 2：PR 自动合并（Auto-merge）
+
+```yaml
+name: Auto Merge
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'  # 仅对 Dependabot PR 自动合并
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_NUMBER"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+```
+
+:::tip[💡 为什么 `fetch-depth: 0` 很重要？]
+
+很多工具（semantic-release、changesets、commitlint 的 `history` 模式）需要完整的 Git 历史来计算版本号。`fetch-depth: 1`（默认）只克隆最新一次提交，会导致这些工具报错或计算错误。
+
+:::
+
+<a id="gitlab-ci"></a>
+## 🦊 GitLab CI 中的 Git 操作
+
+### 基础：`gitlab-ci.yml` 中的 Git 策略
+
+```yaml
+variables:
+  GIT_STRATEGY: clone   # 默认：每个 job 都 clone 代码
+  GIT_DEPTH: 0          # 0 = 全量克隆（类似 GitHub 的 fetch-depth: 0）
+
+stages:
+  - test
+  - build
+  - deploy
+
+test:
+  stage: test
+  script:
+    - npm test
+
+build:
+  stage: build
+  script:
+    - npm run build
+  artifacts:
+    paths:
+      - dist/
+```
+
+### GitLab 特有：`CI_COMMIT_*` 环境变量
+
+| 变量 | 含义 | 示例值 |
+| :--- | :--- | :--- |
+| `CI_COMMIT_SHA` | 当前提交的完整 hash | `a1b2c3d4...` |
+| `CI_COMMIT_SHORT_SHA` | 短 hash | `a1b2c3d` |
+| `CI_COMMIT_REF_NAME` | 分支名或 tag 名 | `main`、`v1.2.0` |
+| `CI_COMMIT_TAG` | 如果是 tag 触发，则是 tag 名 | `v1.2.0` |
+| `CI_PIPELINE_SOURCE` | 触发来源 | `push`、`merge_request_event`、`schedule` |
+
+### 场景：自动创建 Release Tag
+
+```yaml
+create-release:
+  stage: deploy
+  only:
+    - main
+  script:
+    - git config user.email "ci@gitlab.com"
+    - git config user.name "CI Bot"
+    - npm run release:version  # 用 changesets 或 sematic-release 计算版本号
+    - git push --follow-tags origin main  # 推送新 tag
+```
+
+:::warning[⚠️ GitLab CI 中的 `GIT_STRATEGY: fetch`]
+
+`GIT_STRATEGY: fetch` 会复用上一次 job 的工作区（通过 `git fetch` 更新），比 `clone` 快，但可能导致工作区残留文件。大多数情况下用 `clone` 更安全。
+
+:::
+
+<a id="semantic-release"></a>
+## 🏷️ 语义化版本与 Changelog 自动化
+
+### Semantic Versioning 速查
+
+```
+vMAJOR.MINOR.PATCH
+ │      │     │
+ │      │     └── 修复 Bug / 向后兼容的小改动 → 1.2.1
+ │      └──── 新功能 / 向后兼容 → 1.3.0
+ └─────────── 破坏性变更 → 2.0.0
+```
+
+### 工具链选型的考量
+
+| 工具 | 用途 | 推荐场景 |
+| :--- | :--- | :--- |
+| **semantic-release** | 全自动版本号 + Changelog + GitHub Release | CI 自动化程度高的团队 |
+| **Changesets** | 手动标记变更集，PR 合并时自动发版 | Monorepo、需要人工审核发版节奏 |
+| **release-please** | Google 出品，基于 Conventional Commits 自动发版 | 大型项目、多语言 Monorepo |
+| **standard-version** | 本地 CLI 工具，手动触发发版 | 小团队、不喜欢全自动发版 |
+
+### Changesets 实战配置
+
+```bash
+# 1. 安装
+npm install -D @changesets/cli @changesets/github
+
+# 2. 初始化
+npx changeset init
+
+# 3. 每次 PR 添加变更说明
+npx changeset  # 会问你：这是什么类型的变更？（major/minor/patch）
+# 生成 .changeset/abc1234.md
+
+# 4. CI 中自动发版（.github/workflows/release.yml）
+```
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: changesets/action@v1
+        with:
+          publish: npm run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+### 自动生成 Changelog 示例
+
+```markdown
+## 1.3.0 (2024-03-15)
+
+### 🚀 New Features
+- feat(auth): add OAuth2 login support (#1234) @alice
+- feat(dashboard): add usage metrics chart (#1240) @bob
+
+### 🐛 Bug Fixes
+- fix(api): handle null pointer in user service (#1220) @charlie
+
+### 📝 Documentation
+- docs(README): update installation guide (#1215) @diana
+```
+
+:::tip[💡 Changesets vs. Semantic Release 怎么选？]
+
+- **用 Changesets**：你们是 Monorepo、需要人工审核发版节奏、或团队对"全自动发版"不放心
+- **用 Semantic Release**：你们是全自动 CI/CD、信任工具链、希望"合并即发布"
+
+:::
+
+---
+
+## 📝 下一步
+
+- **[📦 大文件与大仓库处理](./large-repo)** —— Git LFS、Monorepo 策略、浅克隆优化
+- **[🖥️ 工作区多开（Git Worktree + AI 编程）](./worktrees)** —— `git worktree` 实现多分支并行开发
+
+:::tip[💡 延伸阅读]
+
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+- [GitLab CI/CD Documentation](https://docs.gitlab.com/ee/ci/)
+- [Semantic Release Documentation](https://semantic-release.gitbook.io/)
+- [Changesets Documentation](https://github.com/changesets/changesets)
+
+:::

--- a/docs/tools/git/commit-conventions.mdx
+++ b/docs/tools/git/commit-conventions.mdx
@@ -1,0 +1,261 @@
+---
+title: ✍️ 提交规范
+sidebar_position: 4
+description: 掌握 Conventional Commits 规范、Commit Message 编写技巧，以及 commitlint + husky 工具配置，建立团队的提交标准。
+---
+
+清晰的 Commit Message 是团队协作的基础设施。它让 `git log` 成为项目的「演变史书」，让 Code Review 更高效，让 `git bisect` 和 `git blame` 真正有用。
+
+<a id="why-conventions-matter"></a>
+## 🤔 为什么需要提交规范
+
+| 问题 | 没有规范 | 有规范 |
+| :--- | :--- | :--- |
+| `git log` 可读性 | 一堆 `fix`、`update`、`wip` | 清晰的变更意图和历史 |
+| Code Review 效率 | Reviewer 需要先猜意图 | Message 本身就是最好的说明 |
+| 自动生成 Changelog | 无法自动化 | `feat:` → Changelog 新功能节 |
+| 语义化版本号 | 无法判断是否需要大版本号 | `BREAKING CHANGE:` → 自动 Major 版本 |
+
+<a id="conventional-commits"></a>
+## 📋 Conventional Commits 规范
+
+[Conventional Commits](https://www.conventionalcommits.org/) 是一套轻量级的 Commit Message 约定，格式如下：
+
+```
+<type>[optional scope]: <subject>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Type 类型
+
+| Type | 说明 | 示例 |
+| :--- | :--- | :--- |
+| `feat` | 新功能（minor 版本） | `feat(auth): add OAuth2 login` |
+| `fix` | Bug 修复（patch 版本） | `fix(api): handle null pointer` |
+| `docs` | 文档变更 | `docs(README): update install guide` |
+| `style` | 代码格式（不影响功能） | `style(linter): fix eslint warnings` |
+| `refactor` | 重构（非 feat/fix） | `refactor(utils): extract date logic` |
+| `perf` | 性能优化 | `perf(query): add index to user_email` |
+| `test` | 测试相关 | `test(auth): add login flow tests` |
+| `build` | 构建/依赖变更 | `build(deps): upgrade react to v18` |
+| `ci` | CI 配置变更 | `ci(github): add PR lint workflow` |
+| `chore` | 其他杂项 | `chore(release): bump v1.2.0` |
+
+### Scope（可选）
+
+`scope` 指明变更影响的范围，通常是模块名或文件名：
+
+```
+feat(auth): ...      # auth 模块
+fix(api): ...        # api 层
+docs(README): ...    # README 文件
+perf(db): ...        # 数据库相关
+```
+
+### Subject 写作原则
+
+`subject` 是最重要的部分，应遵循：
+
+1. **祈使语气**：`add` 而非 `added`/`adds`/`adding`
+2. **首字母小写**（中文可忽略）
+3. **不超过 50 字符**（英文）/ 30 汉字（中文）
+4. **不以句号结尾**
+5. **描述做了什么，而非为什么做**
+
+```
+# ✅ 好的 subject
+feat(auth): add OAuth2 login support
+fix(api): handle null pointer in user service
+refactor(utils): extract date formatting logic
+
+# ❌ 不好的 subject
+added OAuth2 login                  # 过去式
+Feat(auth): Add OAuth2              # 首字母大写
+feat: add OAuth2 and fix bug and update docs  # 太长，不原子
+```
+
+### Body 写作原则
+
+`body` 回答「为什么要做这个变更？」：
+
+```
+fix(auth): prevent duplicate session creation
+
+When a user logged in rapidly clicking the submit button,
+multiple sessions were created due to missing debounce logic.
+
+Added client-side debounce (300ms) and server-side idempotency
+check using Redis lock to prevent race condition.
+
+Fixes #1234
+```
+
+### Footer 写作原则
+
+`footer` 用于引用 Issue/PR，或标记破坏性变更：
+
+```
+Fixes #1234          # 关闭 Issue #1234
+Closes #5678         # 关闭 PR #5678
+Relates to #9012     # 关联 Issue #9012
+
+BREAKING CHANGE: The auth API now requires a Bearer token.
+Old API keys are no longer supported.
+```
+
+<a id="commit-message-tips"></a>
+## ✍️ Commit Message 编写技巧
+
+### 技巧 1：用 `git commit` 而非 `git commit -m`
+
+`-m` 适合快速提交，但重要的提交应该用编辑器写多行 Message：
+
+```bash
+# 会打开编辑器，写多行 message
+git commit
+```
+
+### 技巧 2：`git add -p` 拆分变更
+
+一个文件里同时改了「修 Bug」和「加日志」？用 `git add -p` 拆分：
+
+```bash
+git add -p src/auth.ts
+# y = 暂存这个块    n = 跳过
+# s = 拆更小        e = 手动编辑
+```
+
+### 技巧 3：`git commit --amend` 修正最后一次提交
+
+```bash
+# 修正 message
+git commit --amend -m "fix(auth): correct message"
+
+# 追加文件（不新增提交）
+git add forgotten.ts && git commit --amend --no-edit
+```
+
+:::warning[⚠️ `--amend` 会改写历史]
+
+不要对已经 push 的提交使用 `--amend`，除非你确定在做什么。
+
+:::
+
+### 技巧 4：`git rebase -i` 重写本地历史
+
+Push 之前，用 Interactive Rebase 整理提交：
+
+```bash
+git rebase -i HEAD~3
+# pick = 保留   reword = 改 message
+# edit = 暂停修改   squash = 合并（保留 message）
+# fixup = 合并（丢弃 message）  drop = 删除
+```
+
+<a id="commitlint-husky"></a>
+## 🛠️ 工具配置：commitlint + husky
+
+光有规范文档不够，需要用工具强制执行。
+
+### 安装依赖
+
+```bash
+npm install --save-dev @commitlint/cli @commitlint/config-conventional husky lint-staged
+```
+
+### 配置 commitlint
+
+创建 `commitlint.config.js`：
+
+```js
+/** @type {import('@commitlint/types').UserConfig} */
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'subject-max-length': [2, 'always', 50],
+    'header-max-length': [2, 'always', 72],
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'docs',
+        'style',
+        'refactor',
+        'perf',
+        'test',
+        'build',
+        'ci',
+        'chore',
+      ],
+    ],
+  },
+};
+```
+
+### 配置 husky
+
+```bash
+# 初始化 husky
+npx husky init
+
+# 添加 commit-msg hook（检查 commit message）
+npx husky add .husky/commit-msg 'bun node_modules/.bin/commitlint --edit $1'
+
+# 添加 pre-commit hook（运行 lint-staged）
+# .husky/pre-commit 内容：
+# bun node_modules/.bin/lint-staged
+```
+
+### 配置 lint-staged
+
+在 `package.json` 中添加：
+
+```json
+{
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"],
+    "*.{json,md,css}": ["prettier --write"]
+  }
+}
+```
+
+### 验证配置
+
+```bash
+# 测试 commitlint（应该失败）
+echo "bad commit message" | npx commitlint
+
+# 测试 commitlint（应该通过）
+echo "feat(auth): add login" | npx commitlint
+```
+
+<a id="tools-recommend"></a>
+## 🧰 工具推荐
+
+| 工具 | 用途 | 推荐场景 |
+| :--- | :--- | :--- |
+| **[commitlint](https://commitlint.js.org/)** | 检查 Commit Message 格式 | 团队规范强制执行 |
+| **[commitizen](https://github.com/commitizen/cz-cli)** | 交互式生成规范 Message | 个人/小团队提效 |
+| **[lint-staged](https://github.com/okonet/lint-staged)** | 只对暂存文件运行 Linter | 配合 husky 使用 |
+| **[changesets](https://github.com/changesets/changesets)** | 管理版本号和 Changelog | 库/框架维护者 |
+| **[semantic-release](https://semantic-release.gitbook.io/)** | 全自动版本号和发布 | CI 自动化发布流程 |
+
+---
+
+## 📝 下一步
+
+- **[📝 Git 速查表](./cheat-sheet)** —— 所有常用命令一览
+- **[🛡️ 进阶操作](./advanced)** —— 回顾 Interactive Rebase、Bisect 等进阶技巧
+
+:::tip[💡 延伸阅读]
+
+- [Conventional Commits 官方规范](https://www.conventionalcommits.org/)
+- [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/)
+- [commitlint 官方文档](https://commitlint.js.org/)
+
+:::

--- a/docs/tools/git/conflict-recovery.mdx
+++ b/docs/tools/git/conflict-recovery.mdx
@@ -1,0 +1,266 @@
+---
+title: 💥 冲突解决与灾难恢复
+sidebar_position: 7
+description: 掌握合并冲突处理实战、revert vs reset 抉择、用 reflog 找回丢失提交，以及生产事故的应急回滚流程。
+---
+
+冲突是团队协作中不可避免的现实。如何处理冲突、如何在误操作或生产事故后快速恢复，是每个开发者必须掌握的生存技能。
+
+<a id="merge-conflict"></a>
+## 🔥 合并冲突处理实战
+
+### 冲突是怎么产生的？
+
+```
+你在 feature 分支修改了 src/auth.ts 第 10 行
+你的同事在 main 分支也修改了同一行
+→ Git 无法自动合并，产生冲突
+```
+
+### 冲突标记详解
+
+```
+<<<<<<< HEAD
+const timeout = 5000;  // 你的版本（当前分支）
+=======
+const timeout = 3000;  // 传入分支的版本
+>>>>>>> feature/optimize-timeout
+```
+
+| 标记 | 含义 |
+| :--- | :--- |
+| `<<<<<<< HEAD` | 冲突开始，下面是当前分支的内容 |
+| `=======` | 分隔线，上面是当前分支，下面是传入分支 |
+| `>>>>>>> feature/...` | 冲突结束，标明传入分支名 |
+
+### 解决冲突的标准流程
+
+```bash
+# 1. 发生冲突后，Git 会标记冲突文件
+git status
+# Unmerged paths:
+#   (use "git add <file>..." to mark resolution)
+#         both modified:   src/auth.ts
+
+# 2. 打开冲突文件，找到所有 <<<<<<< 标记
+#    手动编辑，保留正确代码，删除冲突标记
+
+# 3. 暂存解决后的文件
+git add src/auth.ts
+
+# 4. 完成合并提交
+git commit
+```
+
+### 使用工具辅助解决冲突
+
+| 工具 | 类型 | 推荐场景 |
+| :--- | :--- | :--- |
+| **VS Code** | GUI | 内置冲突编辑器，三栏对比，点击按钮选择 |
+| **GitKraken** | 独立 GUI | 可视化分支历史，拖拽合并 |
+| **Sourcetree** | 独立 GUI | 免费，功能全面 |
+| **vimdiff** | TUI | 终端党，`git mergetool` 配置 |
+
+:::tip[💡 VS Code 解决冲突最佳配置]
+
+```json
+// settings.json
+{
+  "git.mergeEditor": true,  // 启用 3-way merge 编辑器
+  "git.conflict.autoNavigate.next": true  // 自动跳到下一个冲突
+}
+```
+
+在冲突文件中，VS Code 会显示 `Accept Current Change`、`Accept Incoming Change`、`Accept Both Changes`、`Compare Changes` 四个按钮。
+
+:::
+
+<a id="revert-vs-reset"></a>
+## ⏪ revert vs. reset 抉择
+
+两个命令都能"撤销"，但机制和适用场景完全不同。
+
+| | `git revert` | `git reset` |
+| :--- | :--- | :--- |
+| **原理** | 创建一个**新提交**，内容是被撤销提交的逆操作 | **移动 HEAD**，直接改写历史 |
+| **历史保留** | ✅ 保留原提交（可追溯） | ❌ 丢弃原提交（除非 reflog 找回） |
+| **可否用于已推送** | ✅ 安全（推荐） | ⚠️ 危险（会改写公共历史） |
+| **适用场景** | 撤销已推送的提交 | 撤销本地未推送的提交 |
+| **命令示例** | `git revert abc1234` | `git reset --hard HEAD~1` |
+
+### 决策树
+
+```
+需要撤销一个提交？
+├── 提交已推送到远程？
+│   └── 是 → git revert（安全）
+│   └── 否 → git reset（或 git rebase -i）
+└── 想完全丢弃本地修改？
+    └── 是 → git reset --hard（危险！）
+    └── 否 → git reset --soft 或 --mixed
+```
+
+### `git reset` 三种模式
+
+```bash
+# --soft：只移动 HEAD，修改留在暂存区（可直接重新提交）
+git reset --soft HEAD~1
+
+# --mixed（默认）：移动 HEAD，修改留在工作区（需重新 git add）
+git reset HEAD~1
+git reset --mixed HEAD~1  # 同上
+
+# --hard：移动 HEAD，修改全部丢弃（不可恢复，除非 reflog）
+git reset --hard HEAD~1
+```
+
+:::danger[🚨 `--hard` 是不可逆的]
+
+`git reset --hard` 会**永久丢弃**工作区和暂存区的所有修改。执行前务必 `git status` 确认没有重要未提交的修改。如果误执行，立即用 `git reflog` 找回。
+
+:::
+
+<a id="reflog-recovery"></a>
+## 🚑 用 reflog 找回丢失提交
+
+`git reflog` 是你的"后悔药"——它记录了 HEAD 的每一次移动，即使提交被 `reset --hard` 丢弃，只要还在 reflog 保留期内（默认 90 天），就能找回。
+
+### 典型场景：误 `reset --hard` 后恢复
+
+```bash
+# 1. 查看 reflog，找到丢失前的状态
+git reflog
+# abc1234 (HEAD -> main) HEAD@{0}: reset: moving to HEAD~3
+# def5678 HEAD@{1}: commit: feat: add user dashboard  ← 这是我们要回到的状态
+# ghi9012 HEAD@{2}: commit: fix: auth timeout
+# jkl3456 HEAD@{3}: commit: docs: update README
+
+# 2. 用 reflog 引用恢复到那个状态
+git reset --hard def5678
+# 或等价写法：
+git reset --hard HEAD@{1}
+
+# 3. 验证恢复结果
+git log --oneline -5
+```
+
+### reflog 引用语法
+
+| 引用 | 含义 |
+| :--- | :--- |
+| `HEAD@{0}` | HEAD 当前位置 |
+| `HEAD@{1}` | HEAD 上一次所在位置 |
+| `HEAD@{2}` | HEAD 上上次所在位置 |
+| `main@{yesterday}` | main 分支昨天的位置 |
+| `main@{1.month.ago}` | main 分支一个月前的位置 |
+
+:::tip[💡 reflog 不是永久的]
+
+reflog 数据会在过期后自动清理（默认 90 天）。如果发现重要提交"消失"了，**越快用 reflog 恢复越好**。超过 90 天，神仙难救。
+
+:::
+
+<a 相同id="production-disaster"></a>
+## 🚨 生产事故应急回滚流程
+
+生产环境出问题了——用户无法登录、数据错误、服务崩溃。此时每一秒都是损失，需要**快速、准确、可回溯**的回滚操作。
+
+### 黄金原则：先恢复服务，再排查原因
+
+```
+P0 事故响应流程：
+1. 确认事故范围（影响多少用户？）
+2. 执行回滚（恢复服务）
+3. 验证恢复（确认服务正常）
+4. 事后排查（找根因，写 Postmortem）
+```
+
+### 场景 1：刚发布的提交导致事故 → `git revert`
+
+```bash
+# 1. 找到导致事故的提交（用 git bisect 或看最近提交）
+git log --oneline -10
+
+# 2. revert 这个提交（会产生一个新提交，内容是被撤销的变更的逆操作）
+git revert abc1234 --no-edit
+
+# 3. 推送回滚提交
+git push origin main
+
+# 4. 验证生产恢复
+```
+
+**为什么用 revert 而不是 reset？**
+- `revert` 不改写历史，其他开发者 `git pull` 会自动获得回滚
+- `reset` 会改写历史，需要所有人同步，容易出错
+
+### 场景 2：无法快速定位事故提交 → 回滚到上一个已知好的版本
+
+```bash
+# 1. 找到上一个稳定版本（看 git tag 或 git log）
+git log --oneline --graph --all | head -20
+
+# 2. 直接用 revert 回滚到那个版本的所有提交（麻烦）
+# 更简单：用 reset --hard 然后 force push（仅限紧急情况）
+git reset --hard v1.2.0
+git push --force-with-lease origin main
+```
+
+:::danger[🚨 `force push` 在生产分支是极度危险操作]
+
+只有在**生产事故、服务已中断、无法用 revert 快速解决**的情况下，才考虑 `git push --force-with-lease`。执行前必须：
+1. 通知所有团队成员"不要 push"
+2. 确认没有其他人正在基于 main 工作
+3. 用 `--force-with-lease` 而非 `--force`（前者会检查远程是否有你不知道的提交）
+
+:::
+
+### 场景 3：数据库迁移脚本导致事故
+
+```bash
+# 数据库迁移是特殊场景——代码可以回滚，但数据迁移可能无法回滚
+# 此时需要：
+# 1. 先回滚代码（git revert）
+# 2. 手动编写"反向迁移"脚本
+# 3. 运行反向迁移，恢复数据
+# 4. 验证数据完整性
+```
+
+### 事故后的 Postmortem 模板
+
+```markdown
+## 事故报告：2024-03-15 用户登录失败
+
+### 影响范围
+- 时间：14:32 - 14:47（15 分钟）
+- 影响：约 30% 用户无法登录
+- 根因：OAuth2 token 刷新逻辑 bug（commit: abc1234）
+
+### 时间线
+- 14:32 部署 v1.3.2
+- 14:33 监控告警：登录失败率 30%
+- 14:35 确认根因：token 刷新超时
+- 14:36 执行回滚（git revert abc1234）
+- 14:38 监控恢复：登录失败率 < 1%
+- 14:47 完全恢复
+
+### 改进措施
+- [ ] 增加登录流程的端到端测试（Deadline: 2024-03-22）
+- [ ] 部署前增加 Canary 发布步骤（Deadline: 2024-03-20）
+- [ ] 接入 PagerDuty 自动告警（Deadline: 2024-03-18）
+```
+
+---
+
+## 📝 下一步
+
+- **[🏭 现代工程化与 CI/CD 集成](./ci-cd)** —— GitHub Actions、GitLab CI 中的 Git 操作
+- **[📦 大文件与大仓库处理](./large-repo)** —— Git LFS、Monorepo 策略、浅克隆优化
+
+:::tip[💡 延伸阅读]
+
+- [Git Reflog - Your Safety Net (Atlassian)](https://www.atlassian.com/git/tutorials/refs-and-the-reflog)
+- [How to revert a Git commit (GitHub Docs)](https://docs.github.com/en/get-started/using-git/undoing-changes)
+- [Postmortem Culture (Google SRE)](https://sre.google/sre-book/postmortem-culture/)
+
+:::

--- a/docs/tools/git/index.mdx
+++ b/docs/tools/git/index.mdx
@@ -22,7 +22,7 @@ position: 3
 本节主要面向：
 
 - **💻 软件开发者**：希望系统学习 Git，建立规范的版本控制习惯。
-- **🧑💼 技术负责人**：需要制定团队的 Git 工作流规范与 Code Review 标准。
+- **👔 技术负责人**：需要制定团队的 Git 工作流规范与 Code Review 标准。
 - **🎓 初学者**：刚接触版本控制，希望从零开始学习 Git。
 - **🔄 迁移用户**：从 SVN、Mercurial 等其他版本控制系统迁移到 Git。
 
@@ -38,8 +38,13 @@ position: 3
 2. **日常工作流**：Status/Add/Commit/Push/Pull 等日常命令，及分支管理基础。
 3. **进阶操作**：Interactive Rebase、Cherry-pick、Reflog、Bisect 等进阶命令详解。
 4. **提交规范**：Conventional Commits 规范、Commit Message 编写技巧、commitlint 工具配置。
-5. **Git 速查表**：汇总核心命令与工作流场景，方便快速查阅。
-6. **常见问题解答（FAQ）**：汇总开发者在使用 Git 过程中遇到的常见痛点与解决方案。
+5. **团队协作与分支策略**：Git Flow、GitHub Flow、Trunk-Based Development 三大主流分支模型对比与选型。
+6. **冲突解决与灾难恢复**：合并冲突处理、revert vs reset、用 reflog 找回丢失提交、生产事故应急流程。
+7. **现代工程化与 CI/CD 集成**：GitHub Actions、GitLab CI 中的 Git 操作、语义化版本与 Changelog 自动化。
+8. **大文件与大仓库处理**：Git LFS、Monorepo 策略（Nx/Turborepo）、浅克隆与部分克隆优化。
+9. **工作区多开（Git Worktree + AI 编程）**：`git worktree` 实现多分支并行开发，配合 AI 编程助手的最佳实践。
+10. **Git 底层原理**：`.git` 目录结构、Blob/Tree/Commit 对象、Packfile、引用与符号引用，深入理解 Git 如何工作。
+11. **Git 速查表**：汇总核心命令与工作流场景，方便快速查阅。
 
 ## 📖 如何使用本节
 
@@ -56,23 +61,53 @@ position: 3
     - [⚖️ Git vs. SVN vs. Mercurial](./intro#git-vs-svn)
   - [🛠️ 安装 Git](./intro#install-git)
     - [📋 系统要求](./intro#system-requirements)
-    - [🏁 安装步骤](./intro#install-steps)
+    - [🏗️ 安装步骤](./intro#install-steps)
   - [⚙️ 初始配置](./intro#initial-config)
   - [🎉 第一次提交](./intro#first-commit)
-- **[🌿 日常工作流](./workflow)** _(待编写)_
+- **[🌿 日常工作流](./workflow)**
   - [📊 三区概念](./workflow#three-areas)
   - [🔄 日常命令](./workflow#daily-commands)
   - [🌿 分支管理基础](./workflow#branch-basics)
-- **[🛡️ 进阶操作](./advanced)** _(待编写)_
+- **[🛡️ 进阶操作](./advanced)**
   - [🔄 Interactive Rebase](./advanced#interactive-rebase)
   - [🔍 Git Bisect 二分查找](./advanced#git-bisect)
   - [📜 Git Reflog 引用日志](./advanced#git-reflog)
   - [🍒 Cherry-pick 遴选提交](./advanced#cherry-pick)
-- **[✍️ 提交规范](./commit-conventions)** _(待编写)_
+- **[✍️ 提交规范](./commit-conventions)**
   - [📋 Conventional Commits 规范](./commit-conventions#conventional-commits)
   - [✍️ Commit Message 编写技巧](./commit-conventions#commit-message-tips)
   - [🛠️ commitlint + husky 强制规范](./commit-conventions#commitlint-husky)
-- **[📝 Git 速查表](./cheat-sheet)** _(待编写)_
+- **[🤝 团队协作与分支策略](./team-collaboration)** _(待编写)_
+  - [🌊 Git Flow 模型](./team-collaboration#git-flow)
+  - [🚀 GitHub Flow 模型](./team-collaboration#github-flow)
+  - [🌳 Trunk-Based Development](./team-collaboration#trunk-based)
+  - [🏆 三大模型对比与选型](./team-collaboration#compare-models)
+- **[💥 冲突解决与灾难恢复](./conflict-recovery)** _(待编写)_
+  - [🔥 合并冲突处理实战](./conflict-recovery#merge-conflict)
+  - [⏪ revert vs. reset 抉择](./conflict-recovery#revert-vs-reset)
+  - [🚑 用 reflog 找回丢失提交](./conflict-recovery#reflog-recovery)
+  - [🚨 生产事故应急回滚流程](./conflict-recovery#production-disaster)
+- **[🏭 现代工程化与 CI/CD 集成](./ci-cd)** _(待编写)_
+  - [🤖 GitHub Actions 中的 Git 操作](./ci-cd#github-actions)
+  - [🔄 GitLab CI 中的 Git 操作](./ci-cd#gitlab-ci)
+  - [🏷️ 语义化版本与 Changelog 自动化](./ci-cd#semantic-release)
+- **[📦 大文件与大仓库处理](./large-repo)** _(待编写)_
+  - [📁 Git LFS 大文件存储](./large-repo#git-lfs)
+  - [🏗️ Monorepo 策略（Nx/Turborepo）](./large-repo#monorepo)
+  - [⚡ 浅克隆与部分克隆优化](./large-repo#shallow-clone)
+- **[🏠 工作区多开（Git Worktree + AI 编程）](./worktrees)** _(待编写)_
+  - [🌲 `git worktree` 基础](./worktrees#worktree-basics)
+  - [🤖 配合 AI 编程助手的最佳实践](./worktrees#ai-pair-programming)
+  - [🏗️ 多分支并行开发工作流](./worktrees#parallel-workflow)
+- **[🔬 Git 底层原理](./internals)** _(待编写)_
+  - [📂 `.git` 目录结构详解](./internals#git-directory)
+  - [🧱 Blob / Tree / Commit 三大对象](./internals#git-objects)
+  - [📦 Packfile 与垃圾回收](./internals#packfile-gc)
+  - [🔗 引用与符号引用](./internals#refs)
+- **[📝 Git 速查表](./cheat-sheet)**
+  - [⚙️ 安装与配置](./cheat-sheet#setup-config)
+  - [🔄 日常基本工作流](./cheat-sheet#basic-workflow)
+  - [📜 历史查看](./cheat-sheet#history-view)
 
 ## 📝 版本说明
 

--- a/docs/tools/git/index.mdx
+++ b/docs/tools/git/index.mdx
@@ -77,30 +77,24 @@ position: 3
   - [📋 Conventional Commits 规范](./commit-conventions#conventional-commits)
   - [✍️ Commit Message 编写技巧](./commit-conventions#commit-message-tips)
   - [🛠️ commitlint + husky 强制规范](./commit-conventions#commitlint-husky)
-- **[🤝 团队协作与分支策略](./team-collaboration)** _(待编写)_
-  - [🌊 Git Flow 模型](./team-collaboration#git-flow)
+- **[🤝 团队协作与分支策略](./team-collaboration)**  - [🌊 Git Flow 模型](./team-collaboration#git-flow)
   - [🚀 GitHub Flow 模型](./team-collaboration#github-flow)
   - [🌳 Trunk-Based Development](./team-collaboration#trunk-based)
   - [🏆 三大模型对比与选型](./team-collaboration#compare-models)
-- **[💥 冲突解决与灾难恢复](./conflict-recovery)** _(待编写)_
-  - [🔥 合并冲突处理实战](./conflict-recovery#merge-conflict)
+- **[💥 冲突解决与灾难恢复](./conflict-recovery)**  - [🔥 合并冲突处理实战](./conflict-recovery#merge-conflict)
   - [⏪ revert vs. reset 抉择](./conflict-recovery#revert-vs-reset)
   - [🚑 用 reflog 找回丢失提交](./conflict-recovery#reflog-recovery)
   - [🚨 生产事故应急回滚流程](./conflict-recovery#production-disaster)
-- **[🏭 现代工程化与 CI/CD 集成](./ci-cd)** _(待编写)_
-  - [🤖 GitHub Actions 中的 Git 操作](./ci-cd#github-actions)
+- **[🏭 现代工程化与 CI/CD 集成](./ci-cd)**  - [🤖 GitHub Actions 中的 Git 操作](./ci-cd#github-actions)
   - [🔄 GitLab CI 中的 Git 操作](./ci-cd#gitlab-ci)
   - [🏷️ 语义化版本与 Changelog 自动化](./ci-cd#semantic-release)
-- **[📦 大文件与大仓库处理](./large-repo)** _(待编写)_
-  - [📁 Git LFS 大文件存储](./large-repo#git-lfs)
+- **[📦 大文件与大仓库处理](./large-repo)**  - [📁 Git LFS 大文件存储](./large-repo#git-lfs)
   - [🏗️ Monorepo 策略（Nx/Turborepo）](./large-repo#monorepo)
   - [⚡ 浅克隆与部分克隆优化](./large-repo#shallow-clone)
-- **[🏠 工作区多开（Git Worktree + AI 编程）](./worktrees)** _(待编写)_
-  - [🌲 `git worktree` 基础](./worktrees#worktree-basics)
+- **[🏠 工作区多开（Git Worktree + AI 编程）](./worktrees)**  - [🌲 `git worktree` 基础](./worktrees#worktree-basics)
   - [🤖 配合 AI 编程助手的最佳实践](./worktrees#ai-pair-programming)
   - [🏗️ 多分支并行开发工作流](./worktrees#parallel-workflow)
-- **[🔬 Git 底层原理](./internals)** _(待编写)_
-  - [📂 `.git` 目录结构详解](./internals#git-directory)
+- **[🔬 Git 底层原理](./internals)**  - [📂 `.git` 目录结构详解](./internals#git-directory)
   - [🧱 Blob / Tree / Commit 三大对象](./internals#git-objects)
   - [📦 Packfile 与垃圾回收](./internals#packfile-gc)
   - [🔗 引用与符号引用](./internals#refs)

--- a/docs/tools/git/index.mdx
+++ b/docs/tools/git/index.mdx
@@ -1,0 +1,88 @@
+---
+title: 🌿 Git 工具
+description: Git 版本控制的最佳实践，涵盖基础使用、高级操作、速查表及常见问题解答。
+position: 3
+---
+
+本节旨在为开发者提供一份全面、实用的 **🌿 Git 使用指南**，帮助你在日常开发中掌握版本控制的核心技能，提升协作效率与代码质量。
+
+## 🎯 教程目标
+
+通过本教程，读者将能够：
+
+- **🧠 掌握核心理念**：深入理解 Git 的设计哲学、分布式架构及三区概念（Working Directory、Staging Area、Repository）。
+- **✍️ 规范提交习惯**：学会编写清晰的 Commit Message，掌握 Conventional Commits 规范。
+- **🌿 熟练分支操作**：掌握分支创建、切换、合并、Rebase 等日常操作。
+- **🛡️ 应对复杂场景**：学会处理合并冲突、回滚错误提交、使用 Git Bisect 二分查找 Bug 等进阶技巧。
+- **🚀 提升工作效率**：利用 Git Aliases、Hooks、GUI 工具等提升日常开发效率。
+- **📝 速查与排错**：通过速查表快速查找常用命令，并获取常见问题的解答。
+
+## 👥 目标读者
+
+本节主要面向：
+
+- **💻 软件开发者**：希望系统学习 Git，建立规范的版本控制习惯。
+- **🧑💼 技术负责人**：需要制定团队的 Git 工作流规范与 Code Review 标准。
+- **🎓 初学者**：刚接触版本控制，希望从零开始学习 Git。
+- **🔄 迁移用户**：从 SVN、Mercurial 等其他版本控制系统迁移到 Git。
+
+:::tip[技术前提]
+
+建议读者具备基本的命令行操作经验，了解软件研发的基本流程。
+
+:::
+
+## 🗺️ 主要内容概览
+
+1. **Git 基础入门**：Git 是什么、为什么用 Git、安装配置、第一次提交。
+2. **日常工作流**：Status/Add/Commit/Push/Pull 等日常命令，及分支管理基础。
+3. **进阶操作**：Interactive Rebase、Cherry-pick、Reflog、Bisect 等进阶命令详解。
+4. **提交规范**：Conventional Commits 规范、Commit Message 编写技巧、commitlint 工具配置。
+5. **Git 速查表**：汇总核心命令与工作流场景，方便快速查阅。
+6. **常见问题解答（FAQ）**：汇总开发者在使用 Git 过程中遇到的常见痛点与解决方案。
+
+## 📖 如何使用本节
+
+- **循序渐进**：建议初学者按照章节顺序学习；有经验的用户可直接跳转到需要的内容。
+- **动手实践**：所有代码块均支持一键复制，动手操作是掌握 Git 的最佳途径。
+- **理解原理**：在记忆命令之前，先理解 Git 的快照机制与三区概念。
+
+## 🧭 目录
+
+- **[🚀 Git 基础入门](./intro)**
+  - [❓ 什么是 Git](./intro#what-is-git)
+    - [💡 Git 的作用](./intro#git-benefits)
+    - [🤔 为什么使用 Git](./intro#why-use-git)
+    - [⚖️ Git vs. SVN vs. Mercurial](./intro#git-vs-svn)
+  - [🛠️ 安装 Git](./intro#install-git)
+    - [📋 系统要求](./intro#system-requirements)
+    - [🏁 安装步骤](./intro#install-steps)
+  - [⚙️ 初始配置](./intro#initial-config)
+  - [🎉 第一次提交](./intro#first-commit)
+- **[🌿 日常工作流](./workflow)** _(待编写)_
+  - [📊 三区概念](./workflow#three-areas)
+  - [🔄 日常命令](./workflow#daily-commands)
+  - [🌿 分支管理基础](./workflow#branch-basics)
+- **[🛡️ 进阶操作](./advanced)** _(待编写)_
+  - [🔄 Interactive Rebase](./advanced#interactive-rebase)
+  - [🔍 Git Bisect 二分查找](./advanced#git-bisect)
+  - [📜 Git Reflog 引用日志](./advanced#git-reflog)
+  - [🍒 Cherry-pick 遴选提交](./advanced#cherry-pick)
+- **[✍️ 提交规范](./commit-conventions)** _(待编写)_
+  - [📋 Conventional Commits 规范](./commit-conventions#conventional-commits)
+  - [✍️ Commit Message 编写技巧](./commit-conventions#commit-message-tips)
+  - [🛠️ commitlint + husky 强制规范](./commit-conventions#commitlint-husky)
+- **[📝 Git 速查表](./cheat-sheet)** _(待编写)_
+
+## 📝 版本说明
+
+Git 是一个持续发展的工具。本节力求记录最新的最佳实践，但由于技术的快速迭代，部分细节可能会随 Git 版本或社区规范的更新而有所变化。
+
+## 🔍 对比官方文档的取舍
+
+- **🗑️ 删除底层原理细节**：删除了 `.git` 目录内部结构、Packfile 格式等底层实现细节，默认读者关注实用技能而非 Git 内核原理，如需深入，请查看 [Git Internals](https://git-scm.com/book/en/v2/Git-Internals-Plumbing-and-Porcelain)。
+- **🏢 删除服务器管理内容**：删除了 Git Server 的 SSH 配置、HTTP 协议搭建等内容，目前更推荐使用 GitHub、GitLab、Gitee 等平台托管，而非自建服务器，如需相关支持，请查看 [Git on the Server](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols)。
+- **🐧 省略环境特定说明**：删除了 macOS、Windows、Linux 各平台的安装差异细节，默认读者可自行完成安装，如需相关支持，请查看 [Getting Started - Installing Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)。
+- **🧹 精简历史迁移内容**：删除了从 SVN、Mercurial、Perforce 等系统迁移到 Git 的详细步骤，如需相关支持，请查看 [Migrating to Git](https://git-scm.com/book/en/v2/Git-and-Other-Systems-Migrating-to-Git)。
+- **📦 省略 Git 属性与过滤器**：删除了 `.gitattributes` 配置、LFS 大文件存储等进阶配置，除需要处理二进制资产的企业场景外对普通开发者意义不大，如需相关支持，请查看 [Git Attributes](https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes)。
+- **🔐 省略 GPG 签名提交**：删除了 GPG Key 配置与签名提交的内容，除开源项目维护者外普通开发者需求较少，如需相关支持，请查看 [Signing Your Work](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work)。

--- a/docs/tools/git/internals.mdx
+++ b/docs/tools/git/internals.mdx
@@ -1,0 +1,266 @@
+---
+title: 🔬 Git 底层原理
+sidebar_position: 11
+description: 深入理解 `.git` 目录结构、Blob/Tree/Commit 三大对象、Packfile 与垃圾回收、引用与符号引用，掌握 Git 如何存储和管理数据。
+---
+
+理解 Git 的底层原理，能让你在遇到奇怪问题时不再"盲猜"，而是能准确判断发生了什么。本章深入探讨 Git 的数据模型和存储机制。
+
+<a id="git-directory"></a>
+## 📂 `.git` 目录结构详解
+
+### 初见 `.git` 目录
+
+```bash
+ls -la .git/
+# HEAD          ← 当前所在分支的引用（指向 refs/heads/main 或直接 hash）
+# config        ← 仓库级配置（git config --local 写的地方）
+# description   ← 仅 GitWeb 使用，其他场景忽略
+# hooks/        ← 客户端/服务端钩子脚本目录
+# index         ← 暂存区（Staging Area）的二进制文件
+# info/         ← 仓库额外信息（exclude 文件等）
+# logs/         ← reflog 数据目录
+# objects/      ← Git 数据库核心！所有数据都存在这里
+# refs/         ← 引用目录（分支、tag、远程跟踪分支）
+# COMMIT_EDITMSG ← 最后一次 commit message（供 --amend 使用）
+```
+
+### `objects/` 目录——Git 的心脏
+
+```bash
+ls .git/objects/
+# 00/  1a/  2f/  ...  ← 每个目录名是 hash 的前 2 位
+# info/           ← 额外的 objects 元数据
+# pack/           ← Packfile 存储目录（压缩后的 objects）
+```
+
+Git 把所有数据（文件内容、目录结构、提交信息）都存为 **object**，用 40 位 SHA-1 hash 作为唯一 ID。
+
+:::tip[💡 为什么是 SHA-1 而不是 SHA-256？]
+
+Git 项目启动于 2005 年，当时 SHA-1 是标准选择。Git 2.29+ 已开始支持 SHA-256，但生态兼容性仍是问题。实际中 SHA-1 碰撞攻击对 Git 的威胁极低（需要控制文件内容并触发 Git 存储，成本极高）。
+
+:::
+
+<a id="git-objects"></a>
+## 🧱 Blob / Tree / Commit 三大对象
+
+Git 有 4 种对象类型，其中最重要的是 **Blob、Tree、Commit**（第 4 种是 Tag 对象）。
+
+### Blob 对象——文件内容
+
+Blob（Binary Large OBject）存储**文件的内容**（不含文件名、不含权限）。
+
+```bash
+# 手动创建一个 blob 对象
+echo "Hello, Git" | git hash-object -w --stdin
+# a1b2c3d4...  ← 这是 blob 的 hash
+
+# 查看 blob 内容
+git cat-file -p a1b2c3d4
+# Hello, Git
+```
+
+| 特性 | 说明 |
+| :--- | :--- |
+| **存储内容** | 文件数据（不含文件名） |
+| **Hash 计算** | `blob <size>\0<content>` |
+| **去重** | 相同内容 → 相同 hash → 只存一份 |
+
+### Tree 对象——目录结构
+
+Tree 存储**目录快照**：它记录了当前目录下有哪些文件（Blob）和子目录（Tree），以及它们的权限和文件名。
+
+```bash
+# 查看一个 tree 对象
+git cat-file -p HEAD^{tree}
+# 100644 blob a1b2c3d4...  README.md
+# 100644 blob e5f6g7h8...  src/index.ts
+# 040000 tree i9j0k1l2...  src/utils
+```
+
+Tree 结构示意：
+
+```
+Commit (abc123)
+  └── Tree (def456)  ← 根目录
+        ├── README.md (blob: ghi789)
+        └── src/ (tree: jkl012)
+              ├── index.ts (blob: mno345)
+              └── utils/ (tree: prs678)
+                    └── helper.ts (blob: tuv901)
+```
+
+### Commit 对象——提交快照
+
+Commit 对象记录了一次提交的所有元数据。
+
+```bash
+# 查看一个 commit 对象
+git cat-file -p HEAD
+# tree def4567890abcdef1234567890abcdef12345678  ← 指向根 tree
+# parent abc1234567890abcdef1234567890abcdef12345  ← 父提交（首次提交无 parent）
+# author Alice <alice@example.com> 1717000000 +0800        ← 作者（写代码的人）
+# committer Bob <bob@example.com> 1717000000 +0800          ← 提交者（执行 git commit 的人）
+#
+# fix: handle token expiration  ← 提交 message
+```
+
+| 字段 | 含义 |
+| :--- | :--- |
+| `tree` | 本次提交对应的根目录 Tree hash |
+| `parent` | 父提交 hash（合并提交有多个 parent） |
+| `author` | 原作者（姓名、邮箱、时间戳） |
+| `committer` | 提交者（rebase 后 author 不变，committer 变） |
+| 消息体 | Commit message |
+
+:::tip[💡 author vs. committer 的区别]
+
+- **author** = 写代码的人（不变，即使被 rebase / cherry-pick）
+- **committer** = 执行 `git commit` 的人（rebase 后会变）
+
+可以通过 `git log --format=fuller` 查看两者。
+
+:::
+
+### 三对象关系图
+
+```
+Commit (v2)
+  ├── tree → Tree (根目录快照)
+  ├── parent → Commit (v1)
+  ├── author: Alice <alice@...>
+  └── message: "fix: bug"
+
+Tree (根目录快照)
+  ├── "README.md" → Blob (内容 hash)
+  └── "src/" → Tree (src 目录)
+                    └── "index.ts" → Blob (内容 hash)
+```
+
+<a id="packfile-gc"></a>
+## 📦 Packfile 与垃圾回收
+
+### 为什么需要 Packfile？
+
+随着提交增多，`.git/objects/` 里会有成千上万个独立文件（每个 blob 一个文件），导致：
+1. **磁盘占用大**——同一个文件修改 100 次，存 100 份完整内容
+2. **访问慢**——随机 I/O 多，克隆时间长
+
+Packfile 把多个 objects 压缩成一个文件，用**增量存储**（只存差异）大幅减少体积。
+
+### Packfile 结构
+
+```bash
+ls .git/objects/pack/
+# pack-abc1234.pack   ← 压缩数据文件
+# pack-abc1234.idx    ← 索引文件（快速查找）
+```
+
+| 文件 | 作用 |
+| :--- | :--- |
+| `.pack` | 压缩后的 objects 数据（增量存储） |
+| `.idx` | 索引，支持 O(1) 查找某个 hash 在 pack 中的位置 |
+
+### 垃圾回收（GC）
+
+```bash
+# 手动触发 GC（Git 会自动在合适时机调用）
+git gc
+
+# 更激进的 GC（会 unpack 再 repack，耗时更长）
+git gc --aggressive
+
+# 查看 objects 统计
+git count-objects -v
+# count: 1234        ← 未打包的 objects 数量
+# size: 45678       ← 未打包的 objects 体积（KB）
+# pack: 56          ← pack 文件数量
+# size-pack: 123456  ← pack 文件总体积（KB）
+```
+
+:::warning[⚠️ `git gc --aggressive` 不要频繁跑]
+
+`--aggressive` 会重新压缩所有 objects，耗时很长（大仓库可能数小时）。日常只需 `git gc`（增量 repack），仅在磁盘空间紧张时才用 `--aggressive`。
+
+:::
+
+<a id="refs"></a>
+## 🔗 引用与符号引用
+
+### 引用（Ref）——指向 Commit 的指针
+
+引用是一个**文本文件**，里面存着一个 commit hash。
+
+```bash
+cat .git/refs/heads/main
+# abc1234567890abcdef1234567890abcdef12345678  ← 这就是 "main 分支"的本质
+
+cat .git/refs/remotes/origin/main
+# def4567890abcdef1234567890abcdef12345678  ← 远程跟踪分支
+```
+
+| 引用类型 | 路径 | 含义 |
+| :--- | :--- | :--- |
+| **分支** | `refs/heads/<name>` | 本地分支，可移动（`git commit` 会自动更新） |
+| **远程跟踪分支** | `refs/remotes/origin/<name>` | 远程分支的本地缓存（`git fetch` 更新） |
+| **Tag** | `refs/tags/<name>` | 标签，通常不可移动 |
+
+### 符号引用（Symbolic Ref）——指向另一个引用
+
+`HEAD` 是最典型的符号引用，它**指向当前分支的引用**（而不是直接指向 commit hash）。
+
+```bash
+cat .git/HEAD
+# ref: refs/heads/main  ← 符号引用：HEAD 指向 main 分支
+
+# 如果处于 "detached HEAD" 状态：
+# abc1234...  ← 直接指向 commit hash，不在任何分支上
+```
+
+### `HEAD` 的三种状态
+
+| 状态 | `HEAD` 内容 | 说明 |
+| :--- | :--- | :--- |
+| **正常（在分支上）** | `ref: refs/heads/main` | `git commit` 会移动 main |
+| **Detached HEAD** | `abc1234...` (直接 hash） | `git commit` 会创建"无分支的提交"（可用 reflog 找回） |
+| **未 born（新仓库）** | `ref: refs/heads/main` 但 main 不存在 | 第一次 `git commit` 后自动创建 |
+
+:::tip[💡 理解 `HEAD^`、`HEAD~2` 等语法的本质]
+
+这些语法操作的是 **DAG（有向无环图）中的 commit 节点**：
+- `HEAD^` = 第一个 parent
+- `HEAD^2` = 第二个 parent（仅合并提交有）
+- `HEAD~2` = 向前 2 代（沿着第一个 parent 链）
+
+它们最终都会被解析为某个 commit hash，git 再拿着 hash 去找对应的 object。
+
+:::
+
+---
+
+## 📝 总结：Git 的数据模型
+
+```
+工作时：你操作的是 Working Directory（文件）
+暂存时：git add → 计算 hash → 写入 objects/（Blob）
+提交时：git commit → 创建 Tree 对象 → 创建 Commit 对象 → 移动 HEAD 引用
+
+存储时：objects/ 里的松散文件 → gc 后压缩为 pack 文件
+引用时：refs/heads/main → commit hash；HEAD → refs/heads/main
+```
+
+理解这套模型后，`git reset --hard`、`git reflog`、`git fsck` 等"高级"命令就不再是黑魔法，而是可推导的操作。
+
+## 📝 下一步
+
+- **[📝 Git 速查表](./cheat-sheet)** —— 所有常用命令一览
+- 回到 **[🚀 Git 基础入门](./intro)** —— 复习基础概念
+
+:::tip[💡 延伸阅读]
+
+- [Git Internals - Plumbing and Porcelain (Pro Git Book)](https://git-scm.com/book/en/v2/Git-Internals-Plumbing-and-Porcelain)
+- [Git from the Bottom Up](https://jwiegley.github.io/git-from-the-bottom-up/)
+- [Git Objects (Atlassian Tutorial)](https://www.atlassian.com/git/tutorials/git-objects)
+
+:::

--- a/docs/tools/git/intro.mdx
+++ b/docs/tools/git/intro.mdx
@@ -1,0 +1,376 @@
+---
+title: 🚀 Git 基础入门
+sidebar_position: 1
+description: 了解 Git 的基本概念、与其他版本控制系统的对比、安装方法及初次提交，开启版本控制之旅。
+---
+
+<a id="what-is-git"></a>
+## ❓ 什么是 Git
+
+Git 是一个**分布式版本控制系统**（Distributed Version Control System），由 Linus Torvalds 在 2005 年创建，用于管理 Linux 内核开发。
+
+与传统的集中式版本控制系统（如 SVN）不同，Git 让每个开发者的本地仓库都拥有完整的历史记录，可以在离线状态下完成几乎所有操作。
+
+<a id="git-benefits"></a>
+### 💡 Git 的作用
+
+- **📖 历史追踪**：记录每一次代码变更，随时可以回溯到任意历史版本。
+- **🤝 并行协作**：多个开发者可以同时工作，通过分支和合并高效整合代码。
+- **🔄 版本回滚**：当新版本出现问题时，可以快速回退到上一个稳定版本。
+- **🧪 实验隔离**：通过分支在隔离环境中尝试新想法，不影响主分支。
+- **📊 责任追溯**：通过 `git blame` 和 `git bisect` 精准定位问题代码和引入者。
+
+<a id="why-use-git"></a>
+### 🤔 为什么使用 Git
+
+在当今软件开发中，Git 已经成为**事实标准**。以下是选择 Git 的核心原因：
+
+| 理由 | 说明 |
+| :--- | :--- |
+| **🌍 市场占有率最高** | 超过 90% 的开发者在使用 Git，GitHub/GitLab 生态极其丰富 |
+| **⚡ 性能卓越** | 本地操作极快，网络断开也能正常工作 |
+| **🛡️ 数据完整性** | 所有提交通过 SHA-1 校验，防止数据损坏或篡改 |
+| **🌿 分支模型优雅** | 创建、切换、合并分支的代价极低，鼓励频繁使用分支 |
+| **📦 分布式架构** | 每个克隆都是完整备份，无单点故障风险 |
+
+<a id="git-vs-svn"></a>
+### ⚖️ Git vs. SVN vs. Mercurial 详细对比
+
+| 特性 | Git | SVN (Subversion) | Mercurial (Hg) |
+| :--- | :--- | :--- | :--- |
+| **架构类型** | 🌍 分布式 | 🏢 集中式 | 🌍 分布式 |
+| **离线工作** | ✅ 完整支持 | ❌ 需要服务器连接 | ✅ 完整支持 |
+| **分支性能** | ⚡ 极快（本地操作） | 🐢 较慢（服务器侧） | ⚡ 极快 |
+| **学习曲线** | 📈 中等（概念较多） | 📉 较平缓 | 📊 中等 |
+| **存储空间** | 📦 高效（压缩+去重） | 📂 较大 | 📦 高效 |
+| **主要用户** | 开源界/互联网公司 | 传统企业/游戏公司 | Facebook（已迁移至 Git）|
+| **推荐场景** | 💻 几乎所有场景 | 🏢 传统企业内部 | 🌐 已逐渐被 Git 取代 |
+
+:::tip[💡 迁移建议]
+
+如果你正在使用 SVN 或 Mercurial，建议尽快迁移到 Git。GitHub 提供了 [导入工具](https://import.github.com/)，大多数迁移可以在几分钟内完成。
+
+:::
+
+<a id="install-git"></a>
+## 🛠️ 安装 Git
+
+<a id="system-requirements"></a>
+### 📋 系统要求
+
+- **Windows**：Windows 7 或更高版本
+- **macOS**：OS X 10.9 或更高版本
+- **Linux**：任意现代发行版（内核 2.6+）
+
+<a id="install-steps"></a>
+### 🏁 安装步骤
+
+<Tabs>
+<TabItem value="windows" label="🪟 Windows">
+
+**方式一：官方安装包（推荐）**
+
+1. 访问 [Git 官方下载页](https://git-scm.com/download/win)
+2. 下载 64-bit Git for Windows Setup
+3. 运行安装程序，按以下建议配置：
+
+| 安装选项 | 推荐选择 | 说明 |
+| :--- | :--- | :--- |
+| Select Components | ✅ Git Bash Here | 右键菜单添加 Git Bash |
+| | ✅ Git GUI Here | 右键菜单添加 Git GUI |
+| Choosing HTTPS transport | ✅ Use the OpenSSL library | 使用系统证书存储 |
+| Configuring line ending conversions | ✅ Checkout as-is, commit as-is | 避免换行符自动转换问题 |
+| Configuring terminal emulator | ✅ Use MinTTY | 更好的终端体验 |
+| Default pull behavior | ✅ Fast-forward or merge | 保守策略，适合初学者 |
+
+**方式二：Winget（Windows 11+）**
+
+```powershell
+winget install --id Git.Git -e --source winget
+```
+
+**方式三：Chocolatey**
+
+```powershell
+choco install git -y
+```
+
+</TabItem>
+<TabItem value="macos" label="🍎 macOS">
+
+**方式一：Homebrew（推荐）**
+
+```bash
+brew install git
+```
+
+**方式二：官方安装包**
+
+访问 [Git 官方下载页](https://git-scm.com/download/mac) 下载 `.dmg` 安装包。
+
+**方式三：Xcode Command Line Tools**
+
+```bash
+xcode-select --install
+```
+
+> 此方法安装的 Git 版本较旧，不推荐长期使用。
+
+</TabItem>
+<TabItem value="linux" label="🐧 Linux">
+
+<Tabs groupId="distro">
+<TabItem value="ubuntu" label="🐧 Ubuntu/Debian">
+
+```bash
+sudo apt update && sudo apt install git -y
+```
+
+</TabItem>
+<TabItem value="fedora" label="🎩 Fedora">
+
+```bash
+sudo dnf install git -y
+```
+
+</TabItem>
+<TabItem value="arch" label="🏔️ Arch Linux">
+
+```bash
+sudo pacman -S git
+```
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+</Tabs>
+
+### ✅ 验证安装
+
+安装完成后，在终端中运行以下命令验证：
+
+```bash
+git --version
+# 输出示例：git version 2.43.0
+```
+
+<a id="initial-config"></a>
+## ⚙️ 初始配置
+
+安装完成后，需要进行一些全局配置。这些配置只需设置一次，除非你需要为不同项目使用不同身份。
+
+<a id="user-config"></a>
+### 👤 配置用户信息
+
+这是**最重要**的配置——每次提交都会使用这些信息：
+
+```bash
+# 配置全局用户名和邮箱
+git config --global user.name "Your Name"
+git config --global user.email "your.email@example.com"
+
+# 验证配置
+git config --global --list
+```
+
+:::warning[⚠️ 注意邮箱地址]
+
+如果你使用 GitHub 或 GitLab，请确保此处填写的邮箱与平台账号的邮箱一致，否则提交记录不会关联到你的账号。
+
+:::
+
+<a id="editor-config"></a>
+### ✏️ 配置默认编辑器
+
+当 Git 需要你输入多行 Commit Message 时，会打开这个编辑器：
+
+```bash
+# VS Code（推荐）
+git config --global core.editor "code --wait"
+
+# Vim（默认，适合熟悉 Vim 的用户）
+git config --global core.editor "vim"
+
+# Nano（对新手友好）
+git config --global core.editor "nano"
+```
+
+<a id="line-ending-config"></a>
+### 🔧 配置换行符处理
+
+不同操作系统使用不同的换行符（Windows: `CRLF`，Linux/macOS: `LF`），配置不当会导致大量无意义的 diff。
+
+```bash
+# Windows 用户（推荐）
+git config --global core.autocrlf false
+git config --global core.safecrlf true
+
+# macOS / Linux 用户（推荐）
+git config --global core.autocrlf input
+```
+
+:::tip[💡 更好的方案：`.gitattributes`]
+
+相比全局配置，在项目根目录添加 `.gitattributes` 文件是更推荐的做法，它可以确保团队成员使用一致的换行符规则：
+
+```
+# .gitattributes
+* text=auto
+*.sh text eol=lf
+*.bat text eol=crlf
+*.png binary
+```
+
+:::
+
+<a id="alias-config"></a>
+### ⚡ 配置常用别名（可选但推荐）
+
+通过别名可以大幅减少打字量：
+
+```bash
+git config --global alias.co checkout
+git config --global alias.br branch
+git config --global alias.ci commit
+git config --global alias.st status
+git config --global alias.unstage 'reset HEAD --'
+git config --global alias.last 'log -1 HEAD'
+git config --global alias.visual '!gitk'
+```
+
+配置后可以使用短命令：
+
+```bash
+git st      # 等同于 git status
+git co       # 等同于 git checkout
+git ci       # 等同于 git commit
+git br       # 等同于 git branch
+```
+
+<a id="first-commit"></a>
+## 🎉 第一次提交
+
+完成配置后，让我们完成第一次 Git 提交，建立对 Git 工作流的直观理解。
+
+<a id="create-repo"></a>
+### 1️⃣ 创建仓库
+
+有两种方式获得一个 Git 仓库：
+
+**方式 A：初始化新仓库（本地项目）**
+
+```bash
+# 创建一个新目录并进入
+mkdir my-project && cd my-project
+
+# 初始化 Git 仓库
+git init
+
+# 查看仓库状态
+git status
+```
+
+**方式 B：克隆已有仓库（参与已有项目）**
+
+```bash
+# 克隆远程仓库到本地
+git clone https://github.com/username/repository.git
+
+# 进入项目目录
+cd repository
+```
+
+<a id="check-status"></a>
+### 2️⃣ 查看状态
+
+```bash
+git status
+# 输出示例：
+# On branch main
+# No commits yet
+# nothing to commit (create/copy files and use "git add" to track)
+```
+
+<a id="create-file"></a>
+### 3️⃣ 创建文件并暂存
+
+```bash
+# 创建一个新文件
+echo "# My Project" > README.md
+
+# 查看状态（文件显示为红色，表示未跟踪）
+git status
+
+# 将文件加入暂存区
+git add README.md
+
+# 再次查看状态（文件显示为绿色，表示已暂存）
+git status
+```
+
+<a id="commit-changes"></a>
+### 4️⃣ 提交变更
+
+```bash
+# 提交暂存区的内容
+git commit -m "feat: add README file"
+
+# 查看提交历史
+git log --oneline
+# 输出示例：
+# abc1234 (HEAD -> main) feat: add README file
+```
+
+:::tip[💡 关于 Commit Message]
+
+`-m` 参数适合快速提交，但对于重要的提交，建议使用多行 Message：
+
+```bash
+# 不加 -m 参数，Git 会打开编辑器让你写多行 Message
+git commit
+```
+
+编辑器中的格式：
+
+```
+feat: add README file
+
+Add project README with basic description and setup instructions.
+
+- Include installation steps
+- Add contribution guidelines reference
+```
+
+:::
+
+<a id="push-remote"></a>
+### 5️⃣ 推送到远程（可选）
+
+如果克隆了远程仓库或添加了远程地址，可以将本地提交推送到远程：
+
+```bash
+# 添加远程仓库地址（仅首次需要）
+git remote add origin https://github.com/username/repository.git
+
+# 推送本地 main 分支到远程
+git push -u origin main
+```
+
+---
+
+## 📝 下一步
+
+恭喜！你已经完成了第一次 Git 提交。接下来建议学习：
+
+- **[🌿 日常工作流](./workflow)** —— 掌握 Status/Add/Commit/Push/Pull 等日常命令
+- **[🛡️ 进阶操作](./advanced)** —— 学习 Rebase、Bisect、Reflog 等进阶技巧
+- **[✍️ 提交规范](./commit-conventions)** —— 编写规范的 Commit Message
+
+:::tip[💡 延伸阅读]
+
+- [Pro Git 中文版（免费电子书）](https://git-scm.com/book/zh/v2)
+- [Git 官方文档](https://git-scm.com/doc)
+- [Learn Git Branching（交互式学习）](https://learngitbranching.js.org/)
+
+:::

--- a/docs/tools/git/intro.mdx
+++ b/docs/tools/git/intro.mdx
@@ -4,6 +4,9 @@ sidebar_position: 1
 description: 了解 Git 的基本概念、与其他版本控制系统的对比、安装方法及初次提交，开启版本控制之旅。
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 <a id="what-is-git"></a>
 ## ❓ 什么是 Git
 

--- a/docs/tools/git/large-repo.mdx
+++ b/docs/tools/git/large-repo.mdx
@@ -1,0 +1,222 @@
+---
+title: 📦 大文件与大仓库处理
+sidebar_position: 9
+description: 掌握 Git LFS 大文件存储、Monorepo 策略（Nx/Turborepo）、浅克隆与部分克隆优化，解决大仓库的性能瓶颈。
+---
+
+当仓库体积超过 1GB、单文件超过 100MB、或提交历史超过 10 万次时，标准 Git 操作会明显变慢。本章介绍三大优化方向。
+
+<a id="git-lfs"></a>
+## 📁 Git LFS——大文件存储
+
+Git LFS（Large File Storage）用"指针文件"替代二进制大文件，让仓库保持轻量。
+
+### 工作原理
+
+```
+Git LFS 前（问题）：
+repo.git/
+  ├── photo.raw (50MB)     ← 每个版本都完整存储！
+  ├── video.mp4 (200MB)    ← 100 个版本 = 20GB！
+  └── ...
+
+Git LFS 后（解决）：
+repo.git/
+  ├── photo.raw (指针，1KB)  ← 只存指针
+  ├── video.mp4 (指针，1KB)
+  └── .git/lfs/             ← 大文件存在这里（服务器）
+```
+
+### 安装与配置
+
+```bash
+# 1. 安装 Git LFS（各平台）
+# macOS: brew install git-lfs
+# Ubuntu: sudo apt install git-lfs
+# Windows: 已包含在 Git for Windows 中
+
+# 2. 初始化（每个仓库只需一次）
+git lfs install
+
+# 3. 跟踪大文件类型
+git lfs track "*.psd"
+git lfs track "*.mp4"
+git lfs track "*.zip"
+
+# 4. 确保 .gitattributes 被提交
+git add .gitattributes
+git commit -m "chore: add Git LFS tracking"
+```
+
+### `.gitattributes` 示例
+
+```
+# 图片
+*.psd filter=lfs diff=lfs merge=lfs -text
+*.ai filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+
+# 视频/音频
+*.mp4 filter=lfs diff=lfs merge=lfs -text
+*.mov filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text
+
+# 数据集/模型
+*.pth filter=lfs diff=lfs merge=lfs -text
+*.h5 filter=lfs diff=lfs merge=lfs -text
+*.csv filter=lfs diff=lfs merge=lfs -text
+```
+
+### 迁移已有大文件到 LFS
+
+```bash
+# 用 git lfs migrate 迁移历史中的大文件
+git lfs migrate import --include="*.psd,*.mp4" --everything
+
+# 推送到远程（会重写历史，需要通知团队）
+git push --force-with-lease origin main
+```
+
+:::warning[⚠️ `git lfs migrate` 会重写历史]
+
+迁移后 commit hash 会改变，所有团队成员需要重新 clone 或 `git reset --hard origin/main`。执行前务必通知团队。
+
+:::
+
+<a id="monorepo"></a>
+## 🏗️ Monorepo 策略
+
+当多个项目共享一个仓库时（Monorepo），Git 性能会成为瓶颈。以下是主流应对方案。
+
+### 方案对比
+
+| 方案 | 适用场景 | 工具链 | 优点 | 缺点 |
+| :--- | :--- | :--- | :--- | :--- |
+| **Nx** | 前端 Monorepo（React/Angular） | Nx + Turborepo | 任务缓存、依赖图分析 | 学习曲线较陡 |
+| **Turborepo** | 前端 Monorepo（通用） | Turborepo | 远程缓存、零配置 | 仅限 JS/TS 生态 |
+| **Bazel** | 大型多语言 Monorepo | Bazel | Google 级性能 | 配置复杂 |
+| **Git Submodules** | 多仓库但想统一管理 | git submodule | 原生支持、轻量 | 操作复杂、容易搞混 |
+| **Git Subtree** | 想把外部仓库合入主仓库 | git subtree | 不用额外工具 | 历史合并复杂 |
+
+### Nx + Turborepo 基础配置
+
+```json
+// turbo.json（Turborepo 配置）
+{
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["build"],
+      "outputs": []
+    }
+  }
+}
+```
+
+```bash
+# Turborepo 远程缓存（加速 CI）
+turbo login
+turbo link
+
+# CI 中自动使用远程缓存
+turbo run build --remote-only
+```
+
+### 什么时候不该用 Monorepo？
+
+```
+✅ 适合 Monorepo：
+- 多个包/应用共享工具和配置
+- 团队在同一代码库协作
+- 需要原子化跨包修改
+
+❌ 不适合 Monorepo：
+- 包之间完全独立，几乎没有共享代码
+- 团队跨时区，协调成本高
+- 单个包体积巨大（> 1GB），影响所有人 clone 速度
+```
+
+:::tip[💡 Monorepo 的性能瓶颈不在 Git，在工具链]
+
+真正慢的是 `npm install`（10 分钟）和 `build`（30 分钟），不是 `git clone`（30 秒）。优化方向应该是：Turborepo 远程缓存、pnpm 硬链接、ESBuild/SWC 替代 Webpack。
+
+:::
+
+<a id="shallow-clone"></a>
+## ⚡ 浅克隆与部分克隆优化
+
+### 浅克隆（Shallow Clone）
+
+```bash
+# 只克隆最近 1 个提交（CI 场景极速）
+git clone --depth=1 https://github.com/user/repo.git
+
+# 克隆指定分支，深度 1
+git clone --depth=1 --branch=main https://github.com/user/repo.git
+
+# 浅克隆后，如何获取完整历史？
+git fetch --unshallow  # 拉取完整历史
+```
+
+| 场景 | 推荐 depth | 说明 |
+| :--- | :--- | :--- |
+| **CI 只跑测试** | `depth=1` | 最快，不需要历史 |
+| **CI 需要 sematic-release** | `depth=0`（全量） | 需要完整历史计算版本号 |
+| **本地开发** | 不浅克隆 | 需要完整历史做 `git log`、`git blame` |
+
+### 部分克隆（Partial Clone）——Git 2.19+
+
+部分克隆允许你**只下载需要的对象**，特别适合大仓库。
+
+```bash
+# 只下载 commit 和 tree 对象，blob 按需下载
+git clone --filter=blob:none https://github.com/large-repo.git
+
+# 更激进：连 tree 也按需下载（Git 2.20+）
+git clone --filter=tree:0 https://github.com/large-repo.git
+```
+
+### 稀疏检出（Sparse Checkout）——只检出部分目录
+
+```bash
+# 1. 初始化稀疏检出
+git sparse-checkout init --cone
+
+# 2. 设置只检出哪些目录
+git sparse-checkout set apps/web packages/ui
+
+# 3. 查看当前稀疏配置
+git sparse-checkout list
+
+# 4. 禁用稀疏检出（恢复完整工作区）
+git sparse-checkout disable
+```
+
+:::tip[💡 三大优化手段对比]
+
+| 手段 | 减少什么 | 适合场景 |
+| :--- | :--- | :--- |
+| **浅克隆** | 历史提交数量 | CI 快速构建 |
+| **部分克隆** | Blob/Tree 对象 | 大仓库日常开发 |
+| **稀疏检出** | 工作区文件数量 | Monorepo 只开发部分应用 |
+
+:::
+
+---
+
+## 📝 下一步
+
+- **[🏠️ 工作区多开（Git Worktree + AI 编程）](./worktrees)** —— `git worktree` 实现多分支并行开发
+- **[🔬 Git 底层原理](./internals)** —— `.git` 目录结构、Blob/Tree/Commit 对象
+
+:::tip[💡 延伸阅读]
+
+- [Git LFS Documentation](https://git-lfs.github.io/)
+- [Turborepo Documentation](https://turbo.build/repo/docs)
+- [Git Partial Clone (GitHub Blog)](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/)
+- [Git Sparse Checkout](https://git-scm.com/docs/git-sparse-checkout)
+
+:::

--- a/docs/tools/git/team-collaboration.mdx
+++ b/docs/tools/git/team-collaboration.mdx
@@ -1,0 +1,197 @@
+---
+title: 🤝 团队协作与分支策略
+sidebar_position: 6
+description: 掌握 Git Flow、GitHub Flow、Trunk-Based Development 三大主流分支模型，学会根据团队规模与发布节奏选择最适合的分支策略。
+---
+
+分支策略是团队协做的核心约定。选对模型，代码集成顺畅；选错模型，合并地狱、发布混乱接踵而至。
+
+本章对比三大主流分支模型，帮助你根据团队规模、发布节奏和风险容忍度做出正确选择。
+
+<a id="git-flow"></a>
+## 🌊 Git Flow——经典但笨重
+
+Git Flow 由 Vincent Driessen 在 2010 年提出，是最早被广泛采用的分支模型。
+
+### 核心结构
+
+```
+main (生产)     ────●───────────●─────────────
+                      \         \
+release/v1.1     ────●─────────●───
+                        \         \
+develop           ────●───●───●───●───●───
+                      \   \   \   \   \
+feature/A  (分支)    ●   ●   ●   ●   ●
+```
+
+| 分支 | 用途 | 生命周期 | 从哪来 | 合到哪去 |
+| :--- | :--- | :--- | :--- | :--- |
+| `main` | 生产环境代码 | 永久 | — | — |
+| `develop` | 集成开发线 | 永久 | `main` | — |
+| `feature/*` | 新功能开发 | 临时 | `develop` | `develop` |
+| `release/*` | 版本发布准备 | 临时 | `develop` | `main` + `develop` |
+| `hotfix/*` | 生产紧急修复 | 临时 | `main` | `main` + `develop` |
+
+### 优缺点
+
+| ✅ 优点 | ❌ 缺点 |
+| :--- | :--- |
+| 结构清晰，适合有计划的版本发布 | 分支多，管理复杂 |
+| `main` 永远稳定，方便回滚 | 合并频繁，冲突概率高 |
+| 支持多个并行版本维护 | 发布周期长，不适合持续交付 |
+| | 新手容易搞混分支关系 |
+
+### 适用场景
+
+- 📦 **版本化产品**（如桌面软件、移动 App）——有清晰的版本号，需要维护多个历史版本
+- 👥 **发布节奏固定**——每 2-4 周一个版本，有专门的发布周期
+- 🔒 **风险容忍度低**——生产发布需要充分测试，不直接从 `develop` 发布
+
+:::warning[⚠️ 2024 年的现实]
+
+Git Flow 在微服务、持续交付的团队中已逐渐被淘汰。如果你做的是 Web 服务或 SaaS 产品，优先考虑 GitHub Flow 或 Trunk-Based。
+
+:::
+
+<a id="github-flow"></a>
+## 🚀 GitHub Flow——简单而高效
+
+GitHub Flow 是 GitHub 在 2011 年推广的轻量级模型，核心哲学：**`main` 永远可发布，功能通过 Pull Request 合并**。
+
+### 核心流程
+
+```
+1. 从 main 创建 feature 分支
+2. 在 feature 分支上提交（可多次 push）
+3. 打开 Pull Request（代码审查）
+4. Review 通过，合并到 main
+5. 立即部署 main 到生产
+```
+
+### 关键规则
+
+| 规则 | 说明 |
+| :--- | :--- |
+| **`main` 永远可发布** | 任何时刻 `main` 都可以部署到生产 |
+| **功能分支从 `main` 创建** | 不用 `develop`，直接基于 `main` |
+| **PR 合并前必须 Review** | 代码质量门禁，至少 1 人 Approve |
+| **合并后立即部署** | CI/CD 自动触发，main 即生产 |
+
+### 与 Git Flow 的对比
+
+| | Git Flow | GitHub Flow |
+| :--- | :--- | :--- |
+| 长期分支 | `main` + `develop` | 只有 `main` |
+| 发布分支 | 有 `release/*` | 无，main 即发布 |
+| 合并频率 | 低（功能 → develop → release → main） | 高（feature → main） |
+| 发布节奏 | 计划性发布 | 持续交付 |
+| 适合场景 | 版本化产品 | Web 服务 / SaaS |
+
+:::tip[💡 为什么 GitHub Flow 更适合现代团队]
+
+在持续交付的环境下，"发布"不再是大事——每次合并都是一次微型发布。GitHub Flow 的分支模型与这个节奏天然契合。
+
+:::
+
+<a id="trunk-based"></a>
+## 🌳 Trunk-Based Development——高频集成
+
+Trunk-Based Development（基于主干开发）是 Google、Meta、Netflix 等顶级工程团队使用的模型。核心哲学：**所有人每天向 `main`（trunk）提交，通过 Feature Flag 而非长期分支管理未完工功能**。
+
+### 核心原则
+
+1. **每天向 `main` 提交**——分支生命周期 < 1 天，最好 < 4 小时
+2. **Feature Flag 而非 Feature Branch**——未完成功能用开关隐藏，不暴露给用户
+3. **严格的 CI 门禁**——每次 push 都跑完整测试套件，阻断不合规代码
+4. **小步提交**——每次提交只改一小件事，方便回滚和 Blame
+
+### 工作流程
+
+```
+开发者 A                  主干 (main)                CI/CD
+───────                  ─────────                ─────
+创建短分支 (可选)   →
+修改代码             →
+跑本地测试           →
+git push            →  触发 CI ─────────────→ 跑测试套件
+                              ↓
+                          通过 ✅
+                              ↓
+                        自动部署到 Staging
+                              ↓
+                        人工验证 (可选)
+                              ↓
+                        自动部署到生产
+```
+
+### 为什么大厂都用 Trunk-Based？
+
+| 痛点 | Git Flow / GitHub Flow | Trunk-Based |
+| :--- | :--- | :--- |
+| **合并冲突** | 功能分支存活数天，冲突频发 | 分支 < 4h，冲突极少 |
+| **集成延迟** | 功能完成才合并，"集成地狱" | 每天多次集成，问题早发现 |
+| **回滚困难** | 大功能一次合并，回滚影响大 | 小提交，精准回滚 |
+| **Feature 暴露** | 分支合并即上线 | Feature Flag 控制，灰度发布 |
+
+### Feature Flag 入门
+
+```javascript
+// 未完工的功能用 Flag 隐藏
+function CheckoutButton() {
+  // FEATURE_CHECKOUT_V2 = false → 旧版本
+  // FEATURE_CHECKOUT_V2 = true  → 新版本
+  if (featureFlag.isEnabled('CHECKOUT_V2')) {
+    return <NewCheckoutFlow />;
+  }
+  return <OldCheckoutFlow />;
+}
+```
+
+:::warning[⚠️ Trunk-Based 的前提条件]
+
+Trunk-Based 不是"随便向 main 提交"，它需要：
+1. **完善的 CI/CD**——每次 push 自动跑测试，失败阻断合并
+2. **Feature Flag 基础设施**——能动态开关功能，支持灰度
+3. **小团队或高度纪律**——每人每天多次提交，需要团队习惯配合
+
+不满足这些条件，强行 Trunk-Based 只会制造混乱。
+
+:::
+
+<a id="compare-models"></a>
+## 🏆 三大模型对比与选型
+
+| 维度 | Git Flow | GitHub Flow | Trunk-Based |
+| :--- | :--- | :--- | :--- |
+| **分支复杂度** | 高（5 类分支） | 低（主要 `main` + feature） | 极低（只有 `main`） |
+| **合并频率** | 低 | 中 | 高（每天多次） |
+| **发布节奏** | 计划性（周/月） | 持续（随时） | 持续（按需） |
+| **适合团队规模** | 小~中（< 20 人） | 中~大（任何规模） | 大（> 50 人，强工程文化） |
+| **适合产品类型** | 版本化（App/桌面） | Web 服务 / SaaS | 大规模 Web 服务 |
+| **CI/CD 要求** | 低 | 中 | 高（必须完善） |
+| **学习曲线** | 陡 | 平缓 | 陡（需要 Feature Flag 经验） |
+
+### 选型建议
+
+```
+团队 < 10 人，做 Web 产品    →  GitHub Flow
+团队 < 10 人，做桌面/移动 App  →  Git Flow（或简化版）
+团队 10-50 人，有 CI/CD      →  GitHub Flow（PR + 自动化测试）
+团队 > 50 人，强工程文化      →  Trunk-Based（Feature Flag + 严格 CI）
+```
+
+---
+
+## 📝 下一步
+
+- **[💥 冲突解决与灾难恢复](./conflict-recovery)** —— 合并冲突处理、revert vs reset、生产事故应急
+- **[🏭 现代工程化与 CI/CD 集成](./ci-cd)** —— GitHub Actions、GitLab CI 中的 Git 操作
+
+:::tip[💡 延伸阅读]
+
+- [Comparing Git Flow and GitHub Flow (GitHub Blog)](https://github.blog/2011/07/15/github-flow/)
+- [Trunk-Based Development (Martin Fowler)](https://martinfowler.com/articles/branching-patterns.html)
+- [Choose Branching Strategy (Azure DevOps)](https://learn.microsoft.com/en-us/azure/devops/repos/git/git-branching-guidance)
+
+:::

--- a/docs/tools/git/workflow.mdx
+++ b/docs/tools/git/workflow.mdx
@@ -1,0 +1,308 @@
+---
+title: 🌿 Git 日常工作流
+sidebar_position: 2
+description: 掌握 Git 三区概念、日常命令（status/add/commit/push/pull）及分支管理基础，建立高效的日常开发工作流。
+---
+
+日常开发中使用 Git 的核心工作流可以概括为：**编辑 → 暂存 → 提交 → 推送**。理解这个循环，以及 Git 的「三区」模型，是掌握 Git 的关键。
+
+<a id="three-areas"></a>
+## 📊 三区概念
+
+Git 的本地工作区分为三个逻辑区域，理解它们的关系是掌握 Git 命令的基础：
+
+```
+┌─────────────────┐
+│                Working Directory（工作区）                │
+│  你正在编辑的文件，尚未被 Git 跟踪或已修改但未暂存        │
+│  git add → 进入 Staging Area                            │
+└─────────────────┘
+                    ↓ git add
+┌─────────────────┐
+│                Staging Area（暂存区 / 索引）             │
+│  已标记将在下一次提交中包含的变更                         │
+│  git commit → 进入 Repository                           │
+└─────────────────┘
+                    ↓ git commit
+┌─────────────────┐
+│                Repository（版本库 / HEAD）                │
+│  已永久记录的提交历史，可通过 git log 查看                │
+│  git push → 推送到远程仓库                              │
+└─────────────────┘
+```
+
+| 区域 | 命令（进入） | 命令（退出/查看） | 文件状态 |
+| :--- | :--- | :--- | :--- |
+| **Working Directory** | 编辑文件 | `git add` | `modified`（已修改）|
+| **Staging Area** | `git add` | `git commit` / `git reset` | `staged`（已暂存）|
+| **Repository** | `git commit` | `git push` | `committed`（已提交）|
+
+:::tip[💡 核心心法]
+
+每次 `git status` 的输出都会告诉你文件在哪个区域，以及用什么命令移动它。**遇到不确定的情况，先 `git status`，再行动。**
+
+:::
+
+<a id="daily-commands"></a>
+## 🔄 日常命令详解
+
+<a id="git-status"></a>
+### `git status` — 查看状态
+
+最常用的命令，没有之一。每次操作前后都应该运行它确认状态：
+
+```bash
+git status
+
+# 输出示例：
+# On branch main
+# Changes to be committed:
+#   (use "git restore --staged <file>..." to unstage)
+#         modified:   src/auth.ts
+#
+# Changes not staged for commit:
+#   (use "add <file>..." to update what will be committed)
+#   (use "restore <file>..." to discard changes in working directory)
+#         modified:   src/utils.ts
+#
+# Untracked files:
+#   (use "git add <file>..." to include in what will be committed)
+#         new-feature.md
+```
+
+<a id="git-add"></a>
+### `git add` — 暂存变更
+
+将工作区的变更放入暂存区，**准备下一次提交**：
+
+```bash
+# 暂存单个文件
+git add src/auth.ts
+
+# 暂存多个文件
+git add src/auth.ts src/utils.ts
+
+# 暂存所有变更（谨慎使用）
+git add .
+
+# 交互式暂存（推荐！逐个代码块选择）
+git add -p
+# 询问每个代码块：y=暂存 n=跳过 s=拆碎 e=手动编辑 q=退出
+```
+
+:::warning[⚠️ `git add .` 的风险]
+
+`git add .` 会暂存**当前目录及子目录的所有变更**，很容易把不想提交的文件（日志、临时文件、node_modules）一起暂存。始终推荐使用 `git add <specific-file>` 或 `git add -p`。
+
+:::
+
+<a id="git-commit"></a>
+### `git commit` — 提交变更
+
+将暂存区的内容创建一个新提交：
+
+```bash
+# 快速提交（单行 message）
+git commit -m "fix(auth): handle token expiration"
+
+# 多行 message（会打开编辑器）
+git commit
+# 编辑器格式：
+# 第一行：subject（<50字符，祈使语气）
+# 空行
+# 正文：解释 Why 和 What（每行<72字符）
+
+# 修正最后一次提交（不新增提交）
+git commit --amend --no-edit    # 追加文件，不改 message
+git commit --amend              # 修改最后一次提交的 message
+
+# 空提交（用于触发 CI 等）
+git commit --allow-empty -m "chore: trigger CI"
+```
+
+<a id="git-push"></a>
+### `git push` — 推送到远程
+
+将本地提交推送到远程仓库：
+
+```bash
+# 推送当前分支到远程（首次需要 -u 绑定）
+git push -u origin main
+
+# 后续推送（已绑定后）
+git push
+
+# 强制推送（危险！会覆盖远程历史）
+git push --force-with-lease   # 比 --force 安全一点，会检查是否有他人推送
+```
+
+:::danger[🚨 强制推送警告]
+
+`git push --force` **会覆盖远程仓库的历史**，可能导致他人的提交丢失。仅在以下情况使用：
+- 你确定只有你在这个分支工作
+- 你正在修复自己刚推送的提交（`--force-with-lease` 更安全）
+
+:::
+
+<a id="git-pull"></a>
+### `git pull` — 拉取远程更新
+
+将远程仓库的更新拉取到本地并合并：
+
+```bash
+# 默认行为：fetch + merge（会产生 merge commit）
+git pull
+
+# 推荐：fetch + rebase（保持历史线性）
+git pull --rebase
+
+# 配置默认使用 rebase（一劳永逸）
+git config --global pull.rebase true
+```
+
+:::tip[💡 Merge vs. Rebase]
+
+| 方式 | 优点 | 缺点 | 适用场景 |
+| :--- | :--- | :--- | :--- |
+| `git pull`（merge）| 保留完整历史 | 产生大量 merge commit，历史非线性 | 新手、团队强制要求 |
+| `git pull --rebase` | 历史线性清晰 | 会改写本地提交时间线 | **推荐日常使用** |
+
+:::
+
+<a id="git-fetch"></a>
+### `git fetch` — 仅拉取不合并
+
+`git pull` = `git fetch` + `git merge`。如果你只想看看远程有什么更新，但不想立即合并：
+
+```bash
+# 拉取所有远程分支的最新数据（不合并）
+git fetch --all
+
+# 查看远程分支和本地分支的差异
+git log HEAD..origin/main --oneline
+```
+
+<a id="branch-basics"></a>
+## 🌿 分支管理基础
+
+分支是 Git 最强大的功能之一。掌握分支操作，才能高效地进行并行开发。
+
+<a id="branch-create"></a>
+### 创建与切换分支
+
+```bash
+# 创建新分支并切换（推荐方式）
+git checkout -b feature/user-profile
+# 或使用新版命令
+git switch -c feature/user-profile
+
+# 仅创建分支（不切换）
+git branch feature/user-profile
+
+# 切换回 main
+git checkout main
+git switch main
+```
+
+<a id="branch-list"></a>
+### 查看分支
+
+```bash
+# 查看本地分支（当前分支前有 * 标记）
+git branch
+
+# 查看所有分支（包括远程）
+git branch -a
+
+# 查看每个分支的最新提交
+git branch -v
+```
+
+<a id="branch-merge"></a>
+### 合并分支
+
+完成功能开发后，将功能分支合并回主分支：
+
+```bash
+# 切换到目标分支（如 main）
+git checkout main
+
+# 合并功能分支
+git merge feature/user-profile
+
+# 合并后删除功能分支（本地）
+git branch -d feature/user-profile
+
+# 删除远程功能分支
+git push origin --delete feature/user-profile
+```
+
+合并时可能遇到**冲突**，Git 会提示：
+
+```
+CONFLICT (content): Merge conflict in src/auth.ts
+Automatic merge failed; fix conflicts and then commit the result.
+```
+
+解决冲突的步骤：
+
+```bash
+# 1. 打开冲突文件，找到冲突标记
+# <<<<<<< HEAD
+# 当前分支的代码
+# =======
+# 要合并的分支的代码
+# >>>>>>> feature/user-profile
+
+# 2. 编辑文件，保留正确代码，删除冲突标记
+
+# 3. 暂存解决后的文件
+git add src/auth.ts
+
+# 4. 完成合并提交
+git commit
+```
+
+<a id="branch-delete"></a>
+### 删除分支
+
+```bash
+# 删除已合并的本地分支
+git branch -d feature/old-feature
+
+# 强制删除未合并的分支（会丢失变更！）
+git branch -D feature/abandoned
+
+# 删除远程分支
+git push origin --delete feature/old-feature
+```
+
+<a id="branch-naming"></a>
+### 分支命名规范
+
+推荐使用以下前缀规范：
+
+| 前缀 | 用途 | 示例 |
+| :--- | :--- | :--- |
+| `feature/` | 新功能开发 | `feature/user-login` |
+| `fix/` | Bug 修复 | `fix/api-timeout` |
+| `hotfix/` | 生产环境紧急修复 | `hotfix/auth-crash` |
+| `chore/` | 杂项（依赖更新、配置） | `chore/deps-update` |
+| `docs/` | 文档变更 | `docs/api-guide` |
+| `refactor/` | 重构 | `refactor/auth-module` |
+
+---
+
+## 📝 下一步
+
+掌握日常工作流后，建议继续学习：
+
+- **[🛡️ 进阶操作](./advanced)** —— Interactive Rebase、Bisect、Reflog、Cherry-pick
+- **[✍️ 提交规范](./commit-conventions)** —— Conventional Commits 规范与工具配置
+
+:::tip[💡 延伸阅读]
+
+- [Pro Git - Git Branching](https://git-scm.com/book/zh/v2/Git-分支-分支简介)
+- [Understanding the Working Directory, Staging Area, and Repository](https://www.freecodecamp.org/news/git-staging-area/)
+
+:::

--- a/docs/tools/git/worktrees.mdx
+++ b/docs/tools/git/worktrees.mdx
@@ -1,0 +1,226 @@
+---
+title: 🖥️ 工作区多开（Git Worktree + AI 编程）
+sidebar_position: 10
+description: 掌握 `git worktree` 实现多分支并行开发，配合 AI 编程助手（Copilot/Cursor/Claude）的最佳实践。
+---
+
+当你需要同时修改多个分支、或让 AI 助手在不同分支上并行工作时，`git worktree` 是你的利器。它让你在同一仓库中拥有**多个工作目录**，每个目录对应不同分支，互不干扰。
+
+<a id="worktree-basics"></a>
+## 🌲 `git worktree` 基础
+
+### 为什么需要 Worktree？
+
+```
+传统方式（问题）：
+├── 你正在 main 分支开发功能 A
+├── 突然需要修一个 hotfix（分支 B）
+├── 你得 stash 或 commit 当前修改
+├── git checkout hotfix-B
+├── 修完，再 checkout main，恢复 stash
+└── 来回切换，效率低下，容易搞混
+
+Worktree 方式（解决）：
+├── 主工作区：/project          → main 分支（功能 A 开发中）
+├── Worktree 1：/project-hotfix  → hotfix-B 分支（紧急修复）
+├── Worktree 2：/project-review  → PR-123 分支（Code Review）
+└── 三个目录同时存在，无需切换！
+```
+
+### 基本操作
+
+```bash
+# 1. 为某个分支创建 worktree（目录自动创建）
+git worktree add ../my-project-feature-a feature-a
+
+# 2. 为新分支创建 worktree（自动创建分支）
+git worktree add -b feature-b ../my-project-feature-b main
+
+# 3. 查看所有 worktree
+git worktree list
+# /home/user/my-project  abc1234 [main]
+# /home/user/my-project-feature-a  def5678 [feature-a]
+# /home/user/my-project-feature-b  ghi9012 [feature-b]
+
+# 4. 删除 worktree（完成后清理）
+git worktree remove ../my-project-feature-a
+
+# 5. 强制删除（worktree 内有未提交修改时）
+git worktree remove --force ../my-project-feature-a
+```
+
+### Worktree 目录结构
+
+```
+~/projects/
+├── my-app/              ← 主仓库（包含 .git 目录）
+│   ├── .git/            ← 这个是"主 .git"，所有 worktree 共享
+│   ├── src/
+│   └── package.json
+├── my-app-feature-a/    ← Worktree 1（只有工作文件，无 .git 目录）
+│   ├── src/             ← 独立的工作区，修改不影响主仓库
+│   └── package.json
+└── my-app-hotfix/      ← Worktree 2
+    └── src/
+```
+
+:::tip[💡 Worktree 的魔法：共享 `.git` 目录]
+
+所有 worktree 共享同一个 `.git` 目录。这意味着：
+- 在一个 worktree 里 `git commit`，其他 worktree 的 `git log` 立即可见
+- 不需要每个 worktree 都 `npm install`（共享 node_modules，前提是不在 `.gitignore` 里）
+- 磁盘占用极省（只有工作文件，没有多份 `.git` 对象）
+
+:::
+
+<a id="ai-pair-programming"></a>
+## 🤖 配合 AI 编程助手的最佳实践
+
+### 场景 1：AI 助手在不同分支并行工作
+
+```
+你：在 main 分支开发功能 A（你自己写代码）
+AI：在 feature-B 分支帮你写功能 B（AI 写代码）
+AI：同时在 hotfix-C 分支修紧急 Bug（AI 写代码）
+
+→ 三个任务并行，不需要来回 stash/checkout
+```
+
+**配置示例（Cursor / VS Code + Copilot）：**
+
+```
+项目根目录/
+├── .cursor/              ← Cursor 配置（AI 上下文）
+├── feature-a/            ← Worktree A（你的工作）
+├── feature-b/            ← Worktree B（AI 写功能 B）
+└── hotfix-c/            ← Worktree C（AI 修 Bug）
+```
+
+在每个 worktree 里打开独立的编辑器窗口：
+
+```bash
+# 终端 1：打开主工作区
+code /home/user/my-app-feature-a
+
+# 终端 2：打开 AI 工作区 B
+code /home/user/my-app-feature-b
+
+# 终端 3：打开 AI 工作区 C
+code /home/user/my-app-hotfix-c
+```
+
+### 场景 2：AI Code Review 专用 Worktree
+
+```bash
+# 为 PR #123 创建 review worktree
+git worktree add ../my-app-pr123 pr/123/head
+
+# 在 review worktree 里让 AI 做 Code Review
+cd ../my-app-pr123
+# 把代码发给 AI："""请 review 这个 PR 的代码，关注：..."""
+```
+
+### 场景 3：A/B 测试两个方案（AI 生成方案 A vs 方案 B）
+
+```bash
+# Worktree A：AI 生成的方案 A
+git worktree add -b experiment-A ../my-app-exp-a main
+cd ../my-app-exp-a
+# AI 在这里实现方案 A
+
+# Worktree B：AI 生成的方案 B
+git worktree add -b experiment-B ../my-app-exp-b main
+cd ../my-app-exp-b
+# AI 在这里实现方案 B
+
+# 两个方案同时运行、对比性能
+cd ../my-app-exp-a && npm run build  # 记录时间
+cd ../my-app-exp-b && npm run build  # 记录时间
+```
+
+:::warning[⚠️ Worktree + AI 的注意事项]
+
+1. **AI 工具可能混淆 worktree 路径**——Cursor/VS Code 有时会缓存错误的 workspace 路径，需要手动确认
+2. **共享 node_modules 的坑**——如果 worktree 之间依赖版本不同，`node_modules` 会冲突。解决方案：每个 worktree 独立 `node_modules`（加到 `.gitignore` 或用 `pnpm` 的 `node_modules/.pnpm` 隔离）
+3. **Git hook 在 worktree 里也会触发**——如果你在 worktree A 里 `git commit`，主仓库的 `pre-commit` hook 也会跑
+
+:::
+
+<a id="parallel-workflow"></a>
+## 🏗️ 多分支并行开发工作流
+
+### 标准 Worktree 工作流
+
+```
+早晨开始工作：
+1. git worktree add ../my-app-feature ../my-app-feature main
+2. cd ../my-app-feature && code .  # 开始开发功能
+
+中午：紧急 hotfix 来了
+3. git worktree add ../my-app-hotfix ../my-app-hotfix main
+4. cd ../my-app-hotfix && code .  # 新窗口修 hotfix
+
+下午：hotfix 修完，发 PR
+5. cd ../my-app-hotfix && git push && gh pr create
+6. git worktree remove ../my-app-hotfix  # 清理
+
+晚上：feature 开发完成
+7. cd ../my-app-feature && git push && gh pr create
+8. git worktree remove ../my-app-feature  # 清理
+```
+
+### 自动化 Worktree 管理脚本
+
+```bash
+#!/bin/bash
+# create-worktree.sh - 快速创建 worktree 并开始工作
+
+BRANCH_NAME=$1
+BASE_BRANCH=${2:-main}
+
+if [ -z "$BRANCH_NAME" ]; then
+  echo "用法: ./create-worktree.sh <branch-name> [base-branch]"
+  exit 1
+fi
+
+WORKTREE_DIR="../my-app-$BRANCH_NAME"
+
+# 创建 worktree
+git worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR" "$BASE_BRANCH"
+
+# 进入 worktree，安装依赖（如果需要）
+cd "$WORKTREE_DIR"
+npm install  # 或 pnpm install
+
+# 打开编辑器
+code .
+
+echo "✅ Worktree 创建成功: $WORKTREE_DIR"
+echo "   分支: $BRANCH_NAME (基于 $BASE_BRANCH)"
+```
+
+:::tip[💡 用 `git worktree` 替代 `git stash` 的场景]
+
+| 场景 | 用 stash | 用 worktree |
+| :--- | :--- | :--- |
+| 临时切换分支修 hotfix（< 30 分钟） | ✅ 合适 | 可以，但略重 |
+| 需要同时运行两个分支对比 | ❌ 做不到 | ✅ 完美 |
+| AI 助手需要独立工作区 | ❌ 做不到 | ✅ 完美 |
+| 长时间（> 1 天）并行开发 | ❌ stash 会忘 | ✅ 完美 |
+
+:::
+
+---
+
+## 📝 下一步
+
+- **[🔬 Git 底层原理](./internals)** —— `.git` 目录结构、Blob/Tree/Commit 对象
+- **[📝 Git 速查表](./cheat-sheet)** —— 所有常用命令一览
+
+:::tip[💡 延伸阅读]
+
+- [Git Worktree Documentation](https://git-scm.com/docs/git-worktree)
+- [Using git worktree for parallel development (ArrowWild)](https://arrowwild.dev/blog/git-worktree)
+- [Cursor AI - Multiple Windows Setup](https://docs.cursor.com)
+
+:::

--- a/docs/tools/index.mdx
+++ b/docs/tools/index.mdx
@@ -16,3 +16,13 @@ description: 汇总各类开发效率工具的配置与使用指南，涵盖 WSL
   - [📝 WSL 速查表](./wsl/cheat-sheet)
 - **[🌿 Git 工具](./git/)**
   - [🚀 Git 基础入门](./git/intro)
+  - [🌿 日常工作流](./git/workflow)
+  - [🛡️ 进阶操作](./git/advanced)
+  - [✍️ 提交规范](./git/commit-conventions)
+  - [🤝 团队协作与分支策略](./git/team-collaboration)
+  - [💥 冲突解决与灾难恢复](./git/conflict-recovery)
+  - [🏗️ 现代工程化与 CI/CD 集成](./git/ci-cd)
+  - [📦 大文件与大仓库处理](./git/large-repo)
+  - [🖥️ 工作区多开](./git/worktrees)
+  - [🔬 Git 底层原理](./git/internals)
+  - [📝 Git 速查表](./git/cheat-sheet)

--- a/docs/tools/index.mdx
+++ b/docs/tools/index.mdx
@@ -14,3 +14,5 @@ description: 汇总各类开发效率工具的配置与使用指南，涵盖 WSL
   - [🛠️ 开发环境配置](./wsl/development)
   - [🛡️ WSL 高级进阶](./wsl/advanced)
   - [📝 WSL 速查表](./wsl/cheat-sheet)
+- **[🌿 Git 工具](./git/)**
+  - [🚀 Git 基础入门](./git/intro)


### PR DESCRIPTION
## Summary

Add full Git tools documentation section (11 articles) to the blog, covering from basics to internals.

## Changes

- `docs/tools/git/index.mdx` - Git tools landing page with full TOC
- `docs/tools/git/intro.mdx` - Git basics (install, config, first commit)
- `docs/tools/git/workflow.mdx` - Daily workflow (status/add/commit/push/pull)
- `docs/tools/git/advanced.mdx` - Advanced operations (rebase, bisect, reflog, cherry-pick)
- `docs/tools/git/commit-conventions.mdx` - Commit message conventions (Conventional Commits)
- `docs/tools/git/team-collaboration.mdx` - Team collaboration & branching strategies
- `docs/tools/git/conflict-recovery.mdx` - Conflict resolution & disaster recovery
- `docs/tools/git/ci-cd.mdx` - CI/CD integration (GitHub Actions, GitLab CI)
- `docs/tools/git/large-repo.mdx` - Large files & monorepo handling (Git LFS, shallow clone)
- `docs/tools/git/worktrees.mdx` - Git worktree + AI pair programming
- `docs/tools/git/internals.mdx` - Git internals (.git structure, objects, packfile)
- `docs/tools/git/cheat-sheet.mdx` - Git cheat sheet (sidebar_position: 99)
- `docs/tools/index.mdx` - Add Git tools entry to tools landing page
- `.husky/pre-commit` - Fix bunx segfault (replace with `bun node_modules/.bin/`)
- `.husky/commit-msg` - Fix bunx segfault (same fix)

## Notes

- All commits are atomic, following Conventional Commits spec
- `cheat-sheet.mdx` sidebar_position set to 99 for future extensibility
- Husky hooks fixed to avoid Bun 1.3.3 segfault with `bunx`